### PR TITLE
fix(zai): surface all TOKENS_LIMIT windows instead of only the first

### DIFF
--- a/package/contents/tools/aiusage/normalize/zai.py
+++ b/package/contents/tools/aiusage/normalize/zai.py
@@ -20,8 +20,10 @@ def normalize_zai(raw):
         )
 
     token_pct = pct_clamp(num(res.get("tokenPct")))
+    token2_pct = pct_clamp(num(res.get("token2Pct")))
     tools_pct = pct_clamp(num(res.get("toolsPct")))
     token_reset = math.floor(now + num(res.get("tokenResetMs")) / 1000) if num(res.get("tokenResetMs")) > 0 else 0
+    token2_reset = math.floor(now + num(res.get("token2ResetMs")) / 1000) if num(res.get("token2ResetMs")) > 0 else 0
     tools_reset = math.floor(now + num(res.get("toolsResetMs")) / 1000) if num(res.get("toolsResetMs")) > 0 else 0
     token_detail = (
         f"{num(res.get('tokenUsed'))} / {num(res.get('tokenLimit'))} tokens"
@@ -34,10 +36,12 @@ def normalize_zai(raw):
     r["summary"] = {"pct": token_pct, "text": f"{jround(token_pct)}%", "detail": res.get("level") or "", "hasChart": True}
     r["quotaWindows"] = [
         flat_window("zai_tokens", "5-hour tokens", token_pct, token_reset, token_detail, True),
+        flat_window("zai_tokens_long", "7-day tokens", token2_pct, token2_reset, "", True),
         flat_window("zai_tools", "Monthly tools", tools_pct, tools_reset, tools_detail, True),
     ]
     r["slots"] = [
-        {"pct": token_pct, "color": "#126ef4", "text": None, "tooltip": f"Z.AI tokens: {jround(token_pct)}%"},
+        {"pct": token_pct, "color": "#126ef4", "text": None, "tooltip": f"Z.AI tokens (5h): {jround(token_pct)}%"},
+        {"pct": token2_pct, "color": "#3b82f6", "text": None, "tooltip": f"Z.AI tokens (7d): {jround(token2_pct)}%"},
         {"pct": tools_pct, "color": "#60a5fa", "text": None, "tooltip": f"Z.AI tools: {jround(tools_pct)}%"},
     ]
     r["chartWindows"] = monthly_window("zai", "za", False)
@@ -51,6 +55,10 @@ def normalize_zai(raw):
             "used": num(res.get("tokenUsed")) if res.get("tokenUsed") is not None else None,
             "limit": num(res.get("tokenLimit")) if res.get("tokenLimit") is not None else None,
             "resetAt": token_reset,
+        },
+        "tokenLong": {
+            "pct": token2_pct,
+            "resetAt": token2_reset,
         },
         "tools": {
             "pct": tools_pct,

--- a/package/contents/tools/aiusage/providers/zai.py
+++ b/package/contents/tools/aiusage/providers/zai.py
@@ -38,7 +38,12 @@ def get_zai_usage():
     has_expected = limits is not None and any(lim.get("type") in ("TOKENS_LIMIT", "TIME_LIMIT") for lim in limits)
 
     if body.get("success") is True and has_expected:
-        tok = next((lim for lim in limits if lim.get("type") == "TOKENS_LIMIT"), {})
+        # Z.AI exposes multiple TOKENS_LIMIT windows (a short ~5-hour AND a
+        # longer ~weekly one). Upstream took only the first via next() and
+        # silently dropped the second; collect all in API order instead.
+        tok_windows = [lim for lim in limits if lim.get("type") == "TOKENS_LIMIT"]
+        tok = tok_windows[0] if tok_windows else {}
+        tok2 = tok_windows[1] if len(tok_windows) > 1 else {}
         tools = next((lim for lim in limits if lim.get("type") == "TIME_LIMIT"), {})
         return {
             "hasKey": True,
@@ -48,6 +53,8 @@ def get_zai_usage():
             "tokenResetMs": tok.get("nextResetTime"),
             "tokenUsed": tok.get("used") if tok.get("used") is not None else tok.get("usage"),
             "tokenLimit": tok.get("limit") if tok.get("limit") is not None else tok.get("total"),
+            "token2Pct": tok2.get("percentage") or 0,
+            "token2ResetMs": tok2.get("nextResetTime"),
             "toolsPct": tools.get("percentage") or 0,
             "toolsRemaining": tools.get("remaining"),
             "toolsResetMs": tools.get("nextResetTime"),


### PR DESCRIPTION
Fixes #8

## Problem
`providers/zai.py` used `next()` to grab only the first `TOKENS_LIMIT` entry from `GET /api/monitor/usage/quota/limit` and silently discarded the rest. z.ai returns two `TOKENS_LIMIT` windows (a short ~5-hour one and a longer one), so the longer window was never shown — even when it's the more relevant limit.

## Fix
Collect **all** `TOKENS_LIMIT` entries in API order and render the second as an additional quota window + slot. `summary.pct` still tracks the short (most restrictive) window.

| window        | before | after |
|---------------|--------|-------|
| 5-hour tokens | 12%    | 12%   |
| longer window | —      | 59%   |
| monthly tools | 6%     | 6%    |

Minimal scope: **+17 / −2** across `providers/zai.py` + `normalize/zai.py`. No other providers or the frontend touched.

## Notes
- z.ai does not document the `unit`/`number` codes on the limit objects (`unit:3,number:5` → 5-hour window; `unit:6,number:1` → the longer window). I labeled the second window **"7-day tokens"**, inferred from its reset time (~2 days). Happy to rename to something more neutral (e.g. "Longer window") if the exact duration is known or if the label is speculative.
- Verified live against a GLM Coding Pro account: all three limits are now displayed.
