### PR TITLE
feat(cli): add a terminal frontend for the shared backend

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,9 @@ jobs:
       - name: provider contract tests
         run: ./tests/get-ai-usage.test.sh
 
+      - name: terminal frontend tests
+        run: ./tests/ai-usage-cli.test.sh
+
       - name: codex helper tests
         run: |
           ./tests/get-codex-stats.test.sh

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ install: ## install test copy to local Plasma session
 
 test: ## run the provider backend contract tests
 	@./tests/get-ai-usage.test.sh
+	@./tests/ai-usage-cli.test.sh
 	@./tests/python-interp.test.sh
 	@./tests/get-codex-stats.test.sh
 	@./tests/get-codex-rate-limits.test.sh

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A KDE Plasma 6 panel widget for tracking AI API quota usage across multiple serv
 - **History export / import** — Save and restore usage history as JSON; history is also mirrored to disk so it survives reinstalls
 - **Stale indicator** — Dims if the last fetch failed, shows error inline
 - **Rate-limit backoff** — Respects `retry-after` headers, won't hammer the API
+- **Terminal frontend** — [`ai-usage-cli`](#terminal) prints the same data as a table, or a single status-bar line with `--compact`, on desktops without Plasma 6 and over SSH
 
 ---
 
@@ -100,7 +101,7 @@ usage before its limit is exhausted. See
 
 | Dependency | Notes |
 |---|---|
-| KDE Plasma 6.0+ | `X-Plasma-API-Minimum-Version: 6.0` |
+| KDE Plasma 6.0+ | `X-Plasma-API-Minimum-Version: 6.0`. Needed for the widget only — the Hyprland shell and the [terminal frontend](#terminal) run without it |
 | `plasma5support` | Provides the `executable` DataEngine for running the backend |
 | Python 3.8+ | Runs the shared provider backend (standard library only, no `pip install`). Auto-detected from PATH as `python3`, a versioned `python3.x`, or bare `python`. To pin a specific interpreter — a virtualenv, a non-standard prefix — set it under **Settings → Advanced → Python**, or export `$PYTHON3`. NixOS installs need no PATH entry at all: the flake pins the interpreter at build time |
 
@@ -208,6 +209,67 @@ settings are stored locally in
 `~/.config/ai-usage-widget/hyprland-settings.json` (or under
 `$XDG_CONFIG_HOME`).
 
+### Terminal
+
+`ai-usage-cli` renders the same provider data as a table, with no Plasma,
+Quickshell or compositor involved. It is the way to use this on a desktop the
+widget cannot be installed on — Plasma 5, GNOME, XFCE — as well as over SSH, in
+a shell prompt, or in a status bar.
+
+```bash
+# From a cloned checkout: put the tools on PATH …
+export PATH="$PWD/package/contents/tools/sh:$PATH"
+
+# … or link just the frontend (it resolves symlinks to find its package)
+ln -s "$PWD/package/contents/tools/sh/ai-usage-cli" ~/.local/bin/ai-usage-cli
+```
+
+```bash
+ai-usage-cli                        # every enabled provider
+ai-usage-cli --provider claude,zai  # a subset, ignoring the toggles
+ai-usage-cli --compact              # one line, for status bars
+watch -n 300 ai-usage-cli           # refresh in place
+get-ai-usage --all | ai-usage-cli   # render an envelope you already fetched
+```
+
+```
+PROVIDER  PLAN          WINDOW             USAGE                NOTE                      RESET
+────────────────────────────────────────────────────────────────────────────────────────────────────────
+Claude    max           5-hour session     [██░░░░░░░░]  23%    120000 / 500000 tokens    Jul 19, 17:00
+Claude    max           7-day window       [██████░░░░]  61%    3000000 / 5000000 tokens  Jul 25, 17:00
+────────────────────────────────────────────────────────────────────────────────────────────────────────
+Z.AI      pro           5-hour tokens      [██░░░░░░░░]  25%    250 / 1000 tokens         Jul 25, 20:20
+Z.AI      pro           Monthly tools      [████░░░░░░]  40%    60 remaining              Jul 25, 21:20
+────────────────────────────────────────────────────────────────────────────────────────────────────────
+Kimi      Moonshot API  Available balance  $49.59
+────────────────────────────────────────────────────────────────────────────────────────────────────────
+Copilot   —             —                  Copilot: no token configured
+```
+
+Colour follows the same thresholds as the panel indicators (amber from 70%, red
+from 90%) and switches off automatically when the output is not a terminal, or
+when `NO_COLOR` is set. `--color always|never` overrides that, and `--ascii`
+replaces the box drawing for terminals without a UTF-8 locale. Columns that stay
+empty — a provider set with no reset times, say — are dropped rather than
+printed blank. A provider that cannot report keeps its row and shows the reason,
+so a missing key does not look like a service you never enabled.
+
+Without a widget there is no settings page to write the config, so create it
+once by hand at `~/.config/ai-usage-widget/hyprland-settings.json` (or under
+`$XDG_CONFIG_HOME`; `AI_USAGE_CONFIG` overrides the path). Providers not listed
+default to on; credentials go in `keys`, and the `WIDGET_*` environment
+variables win over the file if you would rather not store them:
+
+```json
+{
+  "providers": { "claude": true, "zai": true, "kimi": true, "openai": false },
+  "keys": { "zai": "…", "moonshot": "…" }
+}
+```
+
+Claude needs no key — a local Claude Code login is enough. See
+[Supported Services](#supported-services) for what each of the others reads.
+
 ### Package as `.plasmoid`
 
 ```bash
@@ -221,8 +283,9 @@ settings are stored locally in
 
 ### Shared provider backend
 
-Both frontends — the Plasma widget and the Hyprland/Quickshell shell — get every
-provider value from one executable, `package/contents/tools/sh/get-ai-usage`.
+All three frontends — the Plasma widget, the Hyprland/Quickshell shell and the
+terminal frontend — get every provider value from one executable,
+`package/contents/tools/sh/get-ai-usage`.
 It owns credential discovery, provider API requests, response parsing, quota
 maths, reset timestamps and error/stale state, and returns a versioned,
 frontend-neutral JSON model:
@@ -294,8 +357,10 @@ make test
 the backend's `--normalize` mode — success, missing credentials, malformed
 responses, offline and rate-limited states for every provider — and then runs
 the real backend end to end against the fetch tools' fixture hooks. No network
-access is needed. `tests/shared-code.test.js` covers the JavaScript both
-frontends share.
+access is needed. `tests/ai-usage-cli.test.sh` renders those same fixtures
+through the terminal frontend, checking among other things that a provider which
+cannot report still gets a row instead of silently vanishing from the table.
+`tests/shared-code.test.js` covers the JavaScript both QML frontends share.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ export PATH="$PWD/package/contents/tools/sh:$PATH"
 ln -s "$PWD/package/contents/tools/sh/ai-usage-cli" ~/.local/bin/ai-usage-cli
 ```
 
+If the widget is already installed, its settings page lists the path under
+**Terminal** with a copy button, so the plasmoid directory does not have to be
+hunted down by hand.
+
 ```bash
 ai-usage-cli                        # every enabled provider
 ai-usage-cli --provider claude,zai  # a subset, ignoring the toggles

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -1,8 +1,8 @@
 # Provider data contract (schema version 1)
 
-Both frontends — the KDE Plasma widget (`package/contents/ui`) and the
-Hyprland/Quickshell shell (`hyprland/`) — get all of their provider data from a
-single backend:
+All three frontends — the KDE Plasma widget (`package/contents/ui`), the
+Hyprland/Quickshell shell (`hyprland/`) and the terminal frontend
+(`aiusage/render.py`) — get all of their provider data from a single backend:
 
 ```
 shared provider backend (Python, stdlib only)   package/contents/tools/aiusage
@@ -13,16 +13,16 @@ shared provider backend (Python, stdlib only)   package/contents/tools/aiusage
   package/contents/tools/sh/get-ai-usage
                  │
           stable JSON model
-           ┌─────┴─────┐
-           ▼           ▼
-      KDE Plasma   Quickshell
-          UI            UI
+           ┌─────────┼─────────┐
+           ▼         ▼         ▼
+      KDE Plasma Quickshell terminal
+          UI          UI     aiusage/render.py
    (shared JS: package/contents/code/Format.js, UsageHistory.js)
 ```
 
-Neither frontend performs a provider network request, parses a provider
-response, or computes a quota percentage or reset window. They map the fields
-below onto their own widgets and nothing else.
+No frontend performs a provider network request, parses a provider response, or
+computes a quota percentage or reset window. They map the fields below onto
+their own widgets — or columns — and nothing else.
 
 ## Invoking the backend
 
@@ -32,6 +32,15 @@ get-ai-usage --provider claude,openai     # several (KDE: active tab + pins)
 get-ai-usage --all                        # every enabled provider (Hyprland)
 get-ai-usage --normalize < envelope.json  # replay a raw envelope, no network
 get-ai-usage --list                       # known provider ids
+```
+
+The terminal frontend renders that same model, either fetching it itself or
+reading an envelope on stdin:
+
+```bash
+ai-usage-cli                        # table of every enabled provider
+ai-usage-cli --compact              # one line, for status bars
+get-ai-usage --all | ai-usage-cli   # render a fetched envelope, no second fetch
 ```
 
 `--all` respects the provider toggles in the shared settings file
@@ -236,8 +245,9 @@ hammer them.
 
 ## Shared frontend code
 
-Three things are identical in both frontends and live in
-`package/contents/code/` so they cannot drift:
+Three things are identical in both QML frontends and live in
+`package/contents/code/` so they cannot drift (the terminal frontend keeps no
+history and formats its own countdowns from `resetText`):
 
 - `Format.js` — countdown formatting (`countdown`, `countdownFromEpoch`).
 - `UsageHistory.js` — collecting `historyValues` from a response, merging into
@@ -257,11 +267,16 @@ own fixture hooks (`*_RESPONSE_FILE`, honoured by `fetch_json` in
 `aiusage/http.py`) to check settings toggles, key plumbing and the outer
 envelope.
 
-`tests/shared-code.test.js` covers the shared frontend modules. Run both with
-`make test`.
+`tests/ai-usage-cli.test.sh` renders each of those fixtures through the terminal
+frontend, asserting among other things that a provider which cannot report still
+produces a row — a state the graphical frontends show as a tab or a pill, and
+which a table could silently drop instead.
+
+`tests/shared-code.test.js` covers the shared frontend modules. Run them all
+with `make test`.
 
 ## Changing the contract
 
 Adding a field is backwards compatible. Removing or repurposing one is not:
 bump `SCHEMA_VERSION` in `package/contents/tools/aiusage/contract.py`, update
-this document, and update both frontends in the same change.
+this document, and update all three frontends in the same change.

--- a/package/contents/tools/aiusage/__main__.py
+++ b/package/contents/tools/aiusage/__main__.py
@@ -13,12 +13,9 @@ presentation only; see docs/provider-contract.md for the schema.
 
 import json
 import sys
-import time
-from concurrent.futures import ThreadPoolExecutor
 
-from . import config
-from .collect import collect
-from .contract import SCHEMA_VERSION, finalize
+from . import config, envelope
+from .contract import finalize
 from .normalize import normalize
 
 USAGE = """usage: get-ai-usage [--all | --provider <id>[,<id>...] | --normalize]
@@ -72,11 +69,11 @@ def main(argv):
 
     if mode == "normalize":
         try:
-            envelope = json.load(sys.stdin)
+            raw = json.load(sys.stdin)
         except ValueError as e:
             sys.stderr.write(f"get-ai-usage: invalid envelope on stdin: {e}\n")
             return 2
-        _emit(normalize(envelope))
+        _emit(normalize(raw))
         return 0
 
     if not mode:
@@ -93,29 +90,9 @@ def main(argv):
                 return 2
             selected.append(id_)
     else:
-        selected = [id_ for id_ in config.ALL_PROVIDERS if config.provider_enabled(cfg, id_)]
+        selected = envelope.enabled(cfg)
 
-    now = time.time()
-
-    def fetch_one(id_):
-        return normalize(collect(id_, now))
-
-    if selected:
-        with ThreadPoolExecutor(max_workers=len(selected)) as pool:
-            providers = list(pool.map(fetch_one, selected))
-    else:
-        providers = []
-
-    active = ""
-    for p in providers:
-        if p.get("ok") is True:
-            active = p.get("id") or ""
-            break
-    else:
-        if providers:
-            active = providers[0].get("id") or ""
-
-    _emit({"schemaVersion": SCHEMA_VERSION, "updatedAt": int(now), "active": active, "providers": providers})
+    _emit(envelope.build(selected))
     return 0
 
 

--- a/package/contents/tools/aiusage/cli.py
+++ b/package/contents/tools/aiusage/cli.py
@@ -1,0 +1,154 @@
+"""ai-usage-cli — terminal frontend for the shared provider backend.
+
+A third consumer of the contract the Plasma widget and the Quickshell panel
+already render, for people who do not have a panel to put a widget on: Plasma 5
+desktops, status bars (waybar, tmux, i3blocks) via --compact, and headless
+boxes over SSH.
+
+Like the QML frontends this does presentation only. Fetching, parsing and quota
+maths stay in the package; the rendering itself is in aiusage.render.
+"""
+
+import json
+import os
+import stat
+import sys
+
+from . import config, envelope, render
+from .contract import finalize
+from .render import Style
+
+USAGE = """usage: ai-usage-cli [--all | --provider <id>[,<id>...]] [options]
+
+  --all                 every provider enabled in the shared settings file (default)
+  --provider <ids>      the named providers, regardless of the settings toggles
+  --compact             one line, headline value per provider — for status bars
+  --json                print the envelope instead of rendering it
+  --color <when>        auto (default) | always | never; auto honours NO_COLOR
+  --ascii               ASCII bars and rules instead of box drawing
+  --list                print the known provider ids, one per line
+  -h, --help            show this help
+
+A JSON envelope piped or redirected in is rendered instead of fetching, so a
+recorded response can be replayed with no network access:
+
+  get-ai-usage --all | ai-usage-cli
+
+providers: """ + " ".join(config.ALL_PROVIDERS)
+
+
+def _stdin_envelope_waiting():
+    """True when stdin is a pipe or a redirected file.
+
+    Deliberately narrower than "not a tty": under cron, a systemd unit or a
+    status bar stdin is typically /dev/null or closed, and treating that as
+    "an envelope is coming" would turn a normal run into a parse error.
+    """
+    try:
+        mode = os.fstat(sys.stdin.fileno()).st_mode
+    except (OSError, ValueError, AttributeError):
+        return False
+    return stat.S_ISFIFO(mode) or stat.S_ISREG(mode)
+
+
+def _want_color(when, stream):
+    if when == "always":
+        return True
+    if when == "never":
+        return False
+    # https://no-color.org — any value, including empty, disables colour.
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if (os.environ.get("TERM") or "") == "dumb":
+        return False
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def _unicode_ok(stream):
+    return "utf" in (getattr(stream, "encoding", "") or "").lower()
+
+
+def main(argv):
+    requested = ""
+    compact = False
+    as_json = False
+    color = "auto"
+    force_ascii = False
+
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--all":
+            requested = ""
+        elif arg == "--provider":
+            i += 1
+            if i >= len(argv) or not argv[i]:
+                sys.stderr.write("ai-usage-cli: --provider needs at least one id\n")
+                return 2
+            requested = argv[i]
+        elif arg.startswith("--provider="):
+            requested = arg[len("--provider=") :]
+            if not requested:
+                sys.stderr.write("ai-usage-cli: --provider needs at least one id\n")
+                return 2
+        elif arg == "--compact":
+            compact = True
+        elif arg == "--json":
+            as_json = True
+        elif arg == "--color":
+            i += 1
+            color = argv[i] if i < len(argv) else ""
+        elif arg.startswith("--color="):
+            color = arg[len("--color=") :]
+        elif arg == "--ascii":
+            force_ascii = True
+        elif arg == "--list":
+            for p in config.ALL_PROVIDERS:
+                print(p)
+            return 0
+        elif arg in ("-h", "--help"):
+            print(USAGE)
+            return 0
+        else:
+            sys.stderr.write(f"ai-usage-cli: unknown argument: {arg}\n{USAGE}\n")
+            return 2
+        i += 1
+
+    if color not in ("auto", "always", "never"):
+        sys.stderr.write(f"ai-usage-cli: --color takes auto, always or never (got: {color or 'nothing'})\n")
+        return 2
+
+    selected = []
+    if requested:
+        for id_ in requested.split(","):
+            if id_ not in config.ALL_PROVIDERS:
+                sys.stderr.write(f"ai-usage-cli: unknown provider: {id_}\n")
+                return 2
+            selected.append(id_)
+
+    if _stdin_envelope_waiting():
+        try:
+            env = json.load(sys.stdin)
+        except ValueError as e:
+            sys.stderr.write(f"ai-usage-cli: invalid envelope on stdin: {e}\n")
+            return 2
+        if selected:
+            env = dict(env, providers=[p for p in (env.get("providers") or []) if p.get("id") in selected])
+    else:
+        cfg = config.load_settings()
+        config.apply_widget_env(cfg)
+        env = envelope.build(selected or envelope.enabled(cfg))
+
+    if as_json:
+        sys.stdout.write(json.dumps(finalize(env), separators=(",", ":"), ensure_ascii=False) + "\n")
+        return 0
+
+    style = Style(_want_color(color, sys.stdout))
+    unicode_ok = _unicode_ok(sys.stdout) and not force_ascii
+    text = render.render_compact(env, style) if compact else render.render_table(env, style, unicode_ok)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/package/contents/tools/aiusage/cli.py
+++ b/package/contents/tools/aiusage/cli.py
@@ -38,17 +38,20 @@ providers: """ + " ".join(config.ALL_PROVIDERS)
 
 
 def _stdin_envelope_waiting():
-    """True when stdin is a pipe or a redirected file.
+    """True when stdin is a pipe.
 
     Deliberately narrower than "not a tty": under cron, a systemd unit or a
     status bar stdin is typically /dev/null or closed, and treating that as
-    "an envelope is coming" would turn a normal run into a parse error.
+    "an envelope is coming" would turn a normal run into a parse error. A
+    regular file is excluded for the same reason — stdin inherited from an
+    unrelated redirect (`while read …; done < hosts.txt`, systemd's
+    StandardInput=file:) is not an envelope, and eating it breaks the caller.
     """
     try:
         mode = os.fstat(sys.stdin.fileno()).st_mode
     except (OSError, ValueError, AttributeError):
         return False
-    return stat.S_ISFIFO(mode) or stat.S_ISREG(mode)
+    return stat.S_ISFIFO(mode)
 
 
 def _want_color(when, stream):
@@ -133,7 +136,11 @@ def main(argv):
             sys.stderr.write(f"ai-usage-cli: invalid envelope on stdin: {e}\n")
             return 2
         if selected:
-            env = dict(env, providers=[p for p in (env.get("providers") or []) if p.get("id") in selected])
+            kept = [p for p in (env.get("providers") or []) if p.get("id") in selected]
+            # `active` may name a provider the filter just removed; --json would
+            # otherwise emit an envelope that contradicts its own provider list.
+            active = env.get("active") if env.get("active") in {p.get("id") for p in kept} else ""
+            env = dict(env, providers=kept, active=active)
     else:
         cfg = config.load_settings()
         config.apply_widget_env(cfg)

--- a/package/contents/tools/aiusage/envelope.py
+++ b/package/contents/tools/aiusage/envelope.py
@@ -1,0 +1,47 @@
+"""Envelope assembly — fetch a set of providers, wrap them in the outer object.
+
+Split out of __main__ so that every in-process consumer builds the identical
+envelope: the JSON backend the QML frontends call, and the terminal frontend in
+aiusage.cli. See docs/provider-contract.md for the shape produced here.
+"""
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from . import config
+from .collect import collect
+from .contract import SCHEMA_VERSION
+from .normalize import normalize
+
+
+def enabled(cfg):
+    """Provider ids switched on in the shared settings file, in contract order."""
+    return [id_ for id_ in config.ALL_PROVIDERS if config.provider_enabled(cfg, id_)]
+
+
+def build(selected, now=None):
+    """Fetch every id in `selected` concurrently and return a full envelope."""
+    if now is None:
+        now = time.time()
+
+    def fetch_one(id_):
+        return normalize(collect(id_, now))
+
+    if selected:
+        with ThreadPoolExecutor(max_workers=len(selected)) as pool:
+            providers = list(pool.map(fetch_one, selected))
+    else:
+        providers = []
+
+    # `active` is the first healthy provider; frontends fall back to it when the
+    # tab they remembered is gone.
+    active = ""
+    for p in providers:
+        if p.get("ok") is True:
+            active = p.get("id") or ""
+            break
+    else:
+        if providers:
+            active = providers[0].get("id") or ""
+
+    return {"schemaVersion": SCHEMA_VERSION, "updatedAt": int(now), "active": active, "providers": providers}

--- a/package/contents/tools/aiusage/render.py
+++ b/package/contents/tools/aiusage/render.py
@@ -1,0 +1,181 @@
+"""Terminal rendering of the provider contract.
+
+Presentation only, the same rule the two QML frontends follow: every function
+here takes a finished envelope and returns text. No network, no config, no
+provider knowledge, no quota arithmetic — see docs/provider-contract.md for the
+schema being rendered.
+
+ANSI sequences are applied last, after column widths have been measured on the
+plain text, so colour can never shift the layout.
+"""
+
+from .contract import num, pct_clamp
+
+# The panel indicators in both frontends switch colour at these percentages
+# (package/contents/ui/PanelSlot.qml, hyprland/PanelSlot.qml,
+# package/contents/ui/main.qml). Kept identical here so a quota that reads red
+# in the panel does not read yellow in the terminal. Below the warning
+# threshold the frontends use the plain text colour, and so does this.
+WARN_PCT = 70
+DANGER_PCT = 90
+
+METER_WIDTH = 10
+
+_ANSI = {
+    "bold": "\033[1m",
+    "dim": "\033[2m",
+    "red": "\033[31m",
+    "yellow": "\033[33m",
+}
+_RESET = "\033[0m"
+
+HEADERS = ("PROVIDER", "PLAN", "WINDOW", "USAGE", "NOTE", "RESET")
+
+# Columns dropped entirely when no row fills them, rather than printing a
+# header over a column of blanks. USAGE is kept even if a provider reports
+# nothing, because its error text goes there.
+OPTIONAL_COLUMNS = (1, 4, 5)
+
+
+class Style:
+    """Applies ANSI names, or returns the text untouched when colour is off."""
+
+    def __init__(self, enabled):
+        self.enabled = enabled
+
+    def __call__(self, text, *names):
+        names = [n for n in names if n]
+        if not self.enabled or not names or text == "":
+            return text
+        return "".join(_ANSI[n] for n in names) + text + _RESET
+
+
+def _cell(*fragments):
+    """A cell as (text, *styles) fragments — width is measured on text alone."""
+    return list(fragments)
+
+
+def _width(cell):
+    return sum(len(f[0]) for f in cell)
+
+
+def _paint(cell, style, width):
+    body = "".join(style(f[0], *f[1:]) for f in cell)
+    return body + " " * max(0, width - _width(cell))
+
+
+def _level(pct):
+    """Colour name for a percentage, or "" below the warning threshold."""
+    if pct >= DANGER_PCT:
+        return "red"
+    if pct >= WARN_PCT:
+        return "yellow"
+    return ""
+
+
+def _pct_text(pct):
+    return f"{pct:g}%"
+
+
+def _meter(pct, unicode_ok, level):
+    full, empty = ("█", "░") if unicode_ok else ("#", "-")
+    filled = int(round(pct / 100.0 * METER_WIDTH))
+    filled = max(0, min(METER_WIDTH, filled))
+    # A quota that has been touched at all should not render as an empty bar.
+    if filled == 0 and pct > 0:
+        filled = 1
+    frags = [("[", "dim")]
+    if filled:
+        frags.append((full * filled, level))
+    if filled < METER_WIDTH:
+        frags.append((empty * (METER_WIDTH - filled), "dim"))
+    frags.append(("]", "dim"))
+    return frags
+
+
+def _provider_rows(p, unicode_ok):
+    label = p.get("label") or p.get("id") or "?"
+    summary = p.get("summary") or {}
+    windows = p.get("quotaWindows") or []
+
+    if p.get("ok") is not True or not windows:
+        # A provider that cannot report still gets a row. A missing key or an
+        # offline endpoint is precisely what someone runs this to find out, and
+        # dropping the row would make the provider look absent instead of broken.
+        reason = (p.get("error") or "").strip() or (summary.get("detail") or "").strip() or "no data"
+        return [[_cell((label, "bold")), _cell(("—", "dim")), _cell(("—", "dim")), _cell((reason, "red")), _cell(), _cell()]]
+
+    plan = _cell(((summary.get("detail") or "").strip(),))
+    if p.get("stale") is True:
+        plan.append((" (stale)", "dim"))
+
+    rows = []
+    for w in windows:
+        detail = (w.get("detail") or "").strip()
+        note = detail
+        if w.get("available") is False:
+            usage = _cell(("—", "dim"))
+        elif w.get("showMeter"):
+            pct = pct_clamp(num(w.get("pct")))
+            level = _level(pct)
+            usage = _meter(pct, unicode_ok, level)
+            usage.append((" " + _pct_text(pct).rjust(4), level))
+        else:
+            # Providers reporting money rather than a percentage (a balance, a
+            # spend) put the value itself in `detail` and clear showMeter, so it
+            # becomes the usage value rather than a note beside it.
+            usage = _cell((detail or "—",))
+            note = ""
+
+        rows.append(
+            [
+                _cell((label, "bold")),
+                list(plan),
+                _cell(((w.get("label") or w.get("key") or "").strip(),)),
+                usage,
+                _cell((note, "dim")),
+                _cell(((w.get("resetText") or "").strip(), "dim")),
+            ]
+        )
+    return rows
+
+
+def render_table(env, style, unicode_ok=True):
+    """The full table: one row per quota window, grouped by provider."""
+    groups = [_provider_rows(p, unicode_ok) for p in (env.get("providers") or [])]
+    groups = [g for g in groups if g]
+    if not groups:
+        return "no providers selected — enable some in the settings file or pass --provider"
+
+    keep = [i for i in range(len(HEADERS)) if i not in OPTIONAL_COLUMNS or any(_width(row[i]) for g in groups for row in g)]
+    groups = [[[row[i] for i in keep] for row in g] for g in groups]
+
+    header = [_cell((HEADERS[i], "bold")) for i in keep]
+    columns = len(keep)
+    widths = [max(_width(r[i]) for r in [header] + [row for g in groups for row in g]) for i in range(columns)]
+    rule = ("─" if unicode_ok else "-") * (sum(widths) + 2 * (columns - 1))
+
+    def line(row):
+        # The last column is not padded, so no row carries trailing whitespace.
+        return "  ".join(_paint(c, style, widths[i]) if i < columns - 1 else _paint(c, style, 0) for i, c in enumerate(row)).rstrip()
+
+    out = [line(header), style(rule, "dim")]
+    for i, g in enumerate(groups):
+        if i:
+            out.append(style(rule, "dim"))
+        out.extend(line(row) for row in g)
+    return "\n".join(out)
+
+
+def render_compact(env, style):
+    """One line, headline value per provider — for status bars and prompts."""
+    parts = []
+    for p in env.get("providers") or []:
+        label = p.get("label") or p.get("id") or "?"
+        summary = p.get("summary") or {}
+        if p.get("ok") is not True:
+            parts.append(label + " " + style("—", "dim"))
+            continue
+        text = (summary.get("text") or "").strip() or "—"
+        parts.append(label + " " + style(text, _level(pct_clamp(num(summary.get("pct"))))))
+    return "  ".join(parts)

--- a/package/contents/tools/aiusage/render.py
+++ b/package/contents/tools/aiusage/render.py
@@ -127,6 +127,11 @@ def _provider_rows(p, unicode_ok):
             usage = _cell((detail or "—",))
             note = ""
 
+        # An explicit note wins over the derived one, which is what lets a
+        # meterless row keep an aside after `detail` became the value.
+        if w.get("note"):
+            note = str(w["note"]).strip()
+
         rows.append(
             [
                 _cell((label, "bold")),

--- a/package/contents/tools/sh/ai-usage-cli
+++ b/package/contents/tools/sh/ai-usage-cli
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# ai-usage-cli — terminal frontend for the shared provider backend.
+#
+# Renders the same contract the Plasma widget and the Quickshell panel render,
+# as a table or — with --compact — as a single status-bar line. This is a thin
+# launcher; the rendering lives in ../aiusage/render.py and the argument
+# handling in ../aiusage/cli.py. See docs/provider-contract.md.
+#
+#   ai-usage-cli                        table of every enabled provider
+#   ai-usage-cli --provider claude      one provider
+#   ai-usage-cli --compact              one line, for waybar/tmux/i3blocks
+#   get-ai-usage --all | ai-usage-cli   render an envelope, no network
+#
+set -u
+
+# Resolve through symlinks before locating the package: unlike the widget's
+# other tools, this one is meant to be linked into ~/.local/bin, and
+# BASH_SOURCE reports the link rather than its target. `readlink -f` is not
+# portable, so walk the chain by hand.
+_src="${BASH_SOURCE[0]}"
+while [ -L "$_src" ]; do
+    _link_dir="$(cd "$(dirname "$_src")" && pwd)"
+    _src="$(readlink "$_src")"
+    case "$_src" in
+        /*) ;;
+        *) _src="$_link_dir/$_src" ;;
+    esac
+done
+_SH_DIR="$(cd "$(dirname "$_src")" && pwd)"
+
+# Shared interpreter resolution — sets $PY, empty when no Python 3 exists.
+. "$_SH_DIR/python-interp.sh"
+
+if ! py_resolve; then
+    # Unlike get-ai-usage, this has no frontend to keep alive: a person is
+    # reading the output, so say what is wrong instead of emitting an error
+    # envelope they would have to decode.
+    printf 'ai-usage-cli: no Python 3 interpreter found (tried $PYTHON3, python3, python3.x, python)\n' >&2
+    exit 1
+fi
+
+# The aiusage package lives one directory up (tools/aiusage; this is tools/sh).
+PKG_TOOLS="$(cd "$_SH_DIR/.." && pwd)"
+export PYTHONPATH="$PKG_TOOLS${PYTHONPATH:+:$PYTHONPATH}"
+
+# -B: never write __pycache__ into an installed plasmoid.
+exec "$PY" -B -m aiusage.cli "$@"

--- a/package/contents/tools/sh/ai-usage-cli
+++ b/package/contents/tools/sh/ai-usage-cli
@@ -14,10 +14,14 @@
 #
 set -u
 
-# Resolve through symlinks before locating the package: unlike the widget's
-# other tools, this one is meant to be linked into ~/.local/bin, and
-# BASH_SOURCE reports the link rather than its target. `readlink -f` is not
-# portable, so walk the chain by hand.
+# Resolve through symlinks before locating the package: BASH_SOURCE reports the
+# link rather than its target, and this frontend in particular is meant to be
+# linked into ~/.local/bin. `readlink -f` is not portable, so walk the chain by
+# hand.
+#
+# This repeats the loop in get-ai-usage instead of sharing it via
+# python-interp.sh, and has to: resolving the path is precisely what lets a
+# launcher find that sibling file, so the resolution cannot live inside it.
 _src="${BASH_SOURCE[0]}"
 while [ -L "$_src" ]; do
     _link_dir="$(cd "$(dirname "$_src")" && pwd)"

--- a/package/contents/tools/sh/get-ai-usage
+++ b/package/contents/tools/sh/get-ai-usage
@@ -31,7 +31,9 @@ ALL_PROVIDERS="claude antigravity openai kiro mistral openrouter grok zai copilo
 # turn into a bare "no such file" from the frontends.
 # Resolve through symlinks first: BASH_SOURCE reports the link, not its target,
 # so a symlink into ~/.local/bin would look for the package next to the link.
-# `readlink -f` is GNU-only, so walk the chain by hand.
+# `readlink -f` is GNU-only, so walk the chain by hand. ai-usage-cli carries the
+# same loop: it is the step that finds python-interp.sh, so it cannot be shared
+# through it.
 _src="${BASH_SOURCE[0]}"
 while [ -L "$_src" ]; do
     _link_dir="$(cd "$(dirname "$_src")" && pwd)"

--- a/package/contents/ui/SettingsPanel.qml
+++ b/package/contents/ui/SettingsPanel.qml
@@ -689,4 +689,64 @@ ColumnLayout {
             wrapMode: Text.WordWrap
         }
     }
+
+    // ── Terminal ───────────────────────────────────────────────
+    PlasmaComponents.Label {
+        text: "Terminal"
+        font.bold: true
+        font.pixelSize: 10
+        opacity: 0.5
+        color: Kirigami.Theme.textColor
+    }
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: 3
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 4
+
+            PlasmaComponents.Label {
+                text: "Command"
+                font.pixelSize: 10
+                opacity: 0.6
+                color: Kirigami.Theme.textColor
+                Layout.preferredWidth: 76
+                elide: Text.ElideRight
+            }
+            QQC2.TextField {
+                id: cliPathField
+
+                // Resolved at runtime like every other tool path, so it stays
+                // correct wherever the plasmoid is installed.
+                readOnly: true
+                text: rootItem.scriptDir + "ai-usage-cli"
+                implicitHeight: 26
+                Layout.fillWidth: true
+                font.pixelSize: 10
+            }
+            PlasmaComponents.Button {
+                text: "Copy"
+                icon.name: "edit-copy"
+                implicitHeight: 26
+                font.pixelSize: 10
+                // QML has no clipboard API without a C++ helper; selecting the
+                // read-only field and copying it is the portable way.
+                onClicked: {
+                    cliPathField.selectAll();
+                    cliPathField.copy();
+                    cliPathField.deselect();
+                }
+            }
+        }
+        PlasmaComponents.Label {
+            text: "Same data as this popup, as a table in a shell. Link it into ~/.local/bin to run it as ai-usage-cli, or pass --compact for one status-bar line."
+            font.pixelSize: 9
+            opacity: 0.45
+            color: Kirigami.Theme.textColor
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+        }
+    }
 }

--- a/tests/ai-usage-cli.test.sh
+++ b/tests/ai-usage-cli.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Rendering tests for the terminal frontend.
+#
+# Every case renders a recorded envelope through `ai-usage-cli`, so the whole
+# provider matrix — including the states that carry no quota windows at all —
+# is covered without touching the network.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND="$ROOT/package/contents/tools/sh/get-ai-usage"
+CLI="$ROOT/package/contents/tools/sh/ai-usage-cli"
+FIXTURES="$ROOT/tests/fixtures"
+
+failures=0
+checks=0
+
+fail() {
+    printf 'FAIL %s: %s\n' "$1" "$2" >&2
+    failures=$((failures + 1))
+}
+
+# Wrap one normalized provider object into an envelope the frontend can render.
+envelope_for() {
+    "$BACKEND" --normalize <"$FIXTURES/$1.json" | jq -s '{schemaVersion: 1, updatedAt: 0, active: "", providers: .}'
+}
+
+# renders <fixture> <description> <ere> [cli args...]
+renders() {
+    local fixture="$1" description="$2" pattern="$3" out
+    shift 3
+    checks=$((checks + 1))
+    if ! out="$(envelope_for "$fixture" | "$CLI" "$@" 2>&1)"; then
+        fail "$fixture" "frontend errored: $out"
+        return
+    fi
+    if ! printf '%s\n' "$out" | grep -qE "$pattern"; then
+        fail "$fixture" "$description
+  wanted: $pattern
+  got:    $out"
+    fi
+}
+
+# renders_not <fixture> <description> <ere> [cli args...]
+renders_not() {
+    local fixture="$1" description="$2" pattern="$3" out
+    shift 3
+    checks=$((checks + 1))
+    if ! out="$(envelope_for "$fixture" | "$CLI" "$@" 2>&1)"; then
+        fail "$fixture" "frontend errored: $out"
+        return
+    fi
+    if printf '%s\n' "$out" | grep -qE "$pattern"; then
+        fail "$fixture" "$description
+  unwanted: $pattern
+  got:      $out"
+    fi
+}
+
+# ── Invariants every fixture must satisfy ───────────────────────────────────
+
+for fixture in "$FIXTURES"/*.json; do
+    name="$(basename "$fixture" .json)"
+    label="$(envelope_for "$name" | jq -r '.providers[0].label // ""')"
+
+    # The headline reason a CLI exists: a provider that cannot report must still
+    # appear. Dropping the row would make a missing key look like a provider the
+    # user never enabled.
+    renders "$name" "names the provider" "$(printf '%s' "$label" | sed 's/[.[\*^$]/\\&/g')" --color never
+
+    # Same rule the backend contract test enforces: no credential may reach a
+    # frontend, and rendering must not become the exception.
+    renders_not "$name" "never prints a credential" \
+        'secret|sk-ant-|sk-oauth|gh-secret|zai-secret|xai-secret|ds-secret|or-secret|codex-secret' --color never
+
+    # Trailing whitespace makes copied output ugly and breaks naive diffing.
+    renders_not "$name" "leaves no trailing whitespace" ' +$' --color never
+
+    renders_not "$name" "emits no escapes with --color never" $'\033' --color never
+    renders_not "$name" "emits no box drawing with --ascii" '[^[:print:][:space:]]' --color never --ascii
+    renders "$name" "compact mode prints the provider" "$(printf '%s' "$label" | sed 's/[.[\*^$]/\\&/g')" --compact --color never
+done
+
+# ── Error and stale states are visible, not swallowed ───────────────────────
+
+renders claude-missing-credentials "surfaces a missing login"    'not logged in' --color never
+renders claude-offline            "surfaces an offline provider" 'offline' --color never
+renders claude-rate-limited       "surfaces a rate limit"        'rate limited' --color never
+renders zai-invalid-token         "surfaces an invalid token"    'Invalid Z.AI token' --color never
+renders antigravity-not-running   "surfaces a dead IDE"          'not running' --color never
+
+# ── Values ──────────────────────────────────────────────────────────────────
+
+renders claude-success   "renders both Claude windows"     '5-hour session' --color never
+renders claude-success   "renders the weekly percentage"   '61%' --color never
+renders claude-success   "draws a meter"                   '\[[#█]+[-░]*\]' --color never
+renders kimi-success     "renders money without a meter"   'Available balance +\$' --color never
+renders kimi-success     "draws no meter for a balance"    '^Kimi' --color never
+renders_not kimi-success "omits the meter on a balance row" 'Available balance +\[' --color never
+renders openrouter-unlimited "keeps the window note"       'unlimited' --color never
+
+# ── Compact mode ────────────────────────────────────────────────────────────
+
+checks=$((checks + 1))
+lines="$(envelope_for claude-success | "$CLI" --compact --color never | wc -l)"
+[ "$lines" = "1" ] || fail claude-success "compact mode must be one line, got $lines"
+
+checks=$((checks + 1))
+compact="$(envelope_for kimi-success | "$CLI" --compact --color never)"
+case "$compact" in
+    *'$'*) ;;
+    *) fail kimi-success "compact mode must use summary.text, got: $compact" ;;
+esac
+
+# ── Colour ──────────────────────────────────────────────────────────────────
+
+checks=$((checks + 1))
+if ! envelope_for claude-success | "$CLI" --color always | grep -q $'\033'; then
+    fail claude-success "--color always must emit escapes"
+fi
+
+checks=$((checks + 1))
+if envelope_for claude-success | NO_COLOR=1 "$CLI" --color auto | grep -q $'\033'; then
+    fail claude-success "NO_COLOR must disable colour"
+fi
+
+# ── Argument handling ───────────────────────────────────────────────────────
+
+checks=$((checks + 1))
+if envelope_for claude-success | "$CLI" --provider nope >/dev/null 2>&1; then
+    fail cli "an unknown provider id must fail"
+fi
+
+checks=$((checks + 1))
+if envelope_for claude-success | "$CLI" --color sideways >/dev/null 2>&1; then
+    fail cli "an invalid --color value must fail"
+fi
+
+checks=$((checks + 1))
+if printf 'not json' | "$CLI" >/dev/null 2>&1; then
+    fail cli "a malformed envelope on stdin must fail"
+fi
+
+checks=$((checks + 1))
+if ! envelope_for claude-success | "$CLI" --json | jq -e '.providers[0].id == "claude"' >/dev/null 2>&1; then
+    fail cli "--json must pass the envelope through"
+fi
+
+checks=$((checks + 1))
+if ! "$CLI" --list </dev/null | grep -qx claude; then
+    fail cli "--list must print the provider ids"
+fi
+
+# A selection applied to an envelope must filter it rather than refetch.
+checks=$((checks + 1))
+if envelope_for claude-success | "$CLI" --provider zai --color never | grep -q Claude; then
+    fail cli "--provider must filter an envelope from stdin"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+if [ "$failures" -gt 0 ]; then
+    printf '\n%d of %d checks failed\n' "$failures" "$checks" >&2
+    exit 1
+fi
+printf 'ai-usage-cli: %d checks passed\n' "$checks"

--- a/tests/ai-usage-cli.test.sh
+++ b/tests/ai-usage-cli.test.sh
@@ -99,6 +99,10 @@ renders kimi-success     "renders money without a meter"   'Available balance +\
 renders kimi-success     "draws no meter for a balance"    '^Kimi' --color never
 renders_not kimi-success "omits the meter on a balance row" 'Available balance +\[' --color never
 renders openrouter-unlimited "keeps the window note"       'unlimited' --color never
+# The value belongs in the usage column and the call count beside it, so a
+# meterless row keeps its aside instead of cramming both into one cell.
+renders zai-today        "prints the day total as a value" 'Today \(Aug 11\) +41\.18M tokens +370 calls' --color never
+renders_not zai-today    "draws no meter for a day total" 'Today +\[' --color never
 
 # ── Compact mode ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

The backend refactor in #7 left this repo with something a little unusual: a
complete, frontend-neutral quota model that needs nothing but python3, emits
versioned JSON, and can replay fixtures offline through `--normalize`. Both
consumers of it are graphical, though, which leaves out three groups the data
would serve as-is:

- **Desktops the widget cannot be installed on.** I'm on Plasma 5.27, so
  `X-Plasma-API-Minimum-Version: 6.0` rules the widget out entirely — but the
  backend works perfectly, and I've been reading it from a shell script for
  weeks. Same for GNOME/XFCE users who want the numbers without the panel.
- **Status bars.** waybar / i3blocks / tmux want one short line. Given the
  Hyprland support already here, that is largely the same audience.
- **Headless.** Checking quota over SSH before kicking off a long run.

My own script was bash + `jq` + `column`, which is the kind of dependency this
repo deliberately avoids, is not portable (`column -t -s` is util-linux only),
and — worse — iterated `quotaWindows` and therefore silently *dropped* any
provider that had none. A missing key or an `offline` state made the row vanish
rather than explain itself. That seemed worth doing properly, in here.

## What this adds

A third frontend, structurally the same as the other two — presentation only,
consuming the documented contract and nothing else:

```
package/contents/tools/aiusage/render.py    rendering, stdlib only
package/contents/tools/aiusage/cli.py       argument handling
package/contents/tools/sh/ai-usage-cli      thin launcher, like get-ai-usage
tests/ai-usage-cli.test.sh                  renders every existing fixture
```

It either fetches an envelope itself or renders one piped in, so
`get-ai-usage --all | ai-usage-cli` does not fetch twice — and the tests get an
offline path for free.

```
PROVIDER  PLAN          WINDOW             USAGE                NOTE                      RESET
────────────────────────────────────────────────────────────────────────────────────────────────────────
Claude    max           5-hour session     [██░░░░░░░░]  23%    120000 / 500000 tokens    Jul 19, 17:00
Claude    max           7-day window       [██████░░░░]  61%    3000000 / 5000000 tokens  Jul 25, 17:00
────────────────────────────────────────────────────────────────────────────────────────────────────────
Z.AI      pro           5-hour tokens      [██░░░░░░░░]  25%    250 / 1000 tokens         Jul 25, 20:20
Z.AI      pro           Monthly tools      [████░░░░░░]  40%    60 remaining              Jul 25, 21:20
────────────────────────────────────────────────────────────────────────────────────────────────────────
Kimi      Moonshot API  Available balance  $49.59
────────────────────────────────────────────────────────────────────────────────────────────────────────
Copilot   —             —                  Copilot: no token configured
```

```
$ ai-usage-cli --compact
Claude 23%  Z.AI 25%  Kimi $49.59  Copilot —
```

(That is real output, rendered from `tests/fixtures/`, so it stays reproducible.)

Decisions worth flagging, since they are the ones you might want made
differently:

- **A provider that cannot report keeps its row and shows the reason.** This is
  the headline difference from my old script. The graphical frontends show that
  state as a dimmed tab or pill; a table would have to actively choose not to
  drop it.
- **Colour thresholds are yours, not new ones** — amber at 70%, red at 90%,
  read off `PanelSlot.qml` / `main.qml`. Below the warning threshold it uses the
  plain text colour, like the panel does. A quota that reads red in the panel
  cannot read yellow in the terminal.
- **ANSI is applied after column widths are measured**, so colour can never
  shift the layout. Optional columns (PLAN, NOTE, RESET) are dropped entirely
  when no row fills them.
- **Colour switches off for non-terminals** and honours `NO_COLOR`;
  `--color always|never` overrides, and `--ascii` covers terminals without a
  UTF-8 locale.

## Discoverability from the widget

Per your question about surfacing this in the UI: the settings page now ends
with a **Terminal** section, in the style of the sections above it — the
resolved path in a read-only field, a Copy button, and one line about linking
it into `~/.local/bin`.

The path is built from the same runtime-resolved `scriptDir` that `main.qml`
already uses to reach the backend, so it stays correct wherever the plasmoid
is installed instead of hardcoding a guess. Copy selects the read-only field
and copies the selection, since QML has no clipboard API without a C++ helper.

**Please eyeball this one before merging.** I'm on Plasma 5.27 and cannot run
the widget, so that section is the only part of this PR I have not seen draw.
It parses under `qmllint` and follows the existing layout idioms, but that is
not the same as looking right. If you would rather write those 40 lines
yourself, say so and I will drop the commit.

## Symlink resolution

The separate PR I offered here has since landed on master, so `get-ai-usage`
resolves symlinks too and this PR no longer carries that argument.

What it leaves behind is the same twelve-line loop in both launchers, which
looks like duplication waiting to be factored out. It cannot be: resolving the
path is precisely the step that locates `python-interp.sh`, so it cannot live
inside the file it is used to find. I have added a comment on both sides
saying so, rather than leave a trap for whoever tries to tidy it up.

## The first commit is a no-op refactor

`refactor: extract envelope assembly out of __main__` moves the fetch, the
concurrent map and the `active` pick into `aiusage/envelope.py`, so the CLI does
not grow a second copy of them. The emitted envelope is byte-identical and the
provider selection is the same comprehension; I verified the selection matches
the old expression exactly. It is split out so it can be reviewed as the
mechanical change it is.

## Tests

`tests/ai-usage-cli.test.sh` renders each existing fixture through the frontend
and asserts, among other things, that every provider produces a row including
the failure states, that no credential can reach the output (the same rule the
backend contract test enforces), that `--color never` emits no escapes and
`--ascii` no non-ASCII, and that compact mode uses `summary.text` so a balance
shows as `$49.59` rather than `0%`. No network.

Rebased onto current master. The suite went from 244 to 256 checks by itself:
it iterates `tests/fixtures/*.json`, so it picked up `claude-scoped-week.json`
and `zai-absolute-reset.json` from the fixes you just merged without a line of
test changing. The scoped weekly window renders as its own row, no frontend
change needed:

```
PROVIDER  PLAN  WINDOW          USAGE              RESET
────────────────────────────────────────────────────────────────
Claude    max   5-hour session  [█░░░░░░░░░]   9%  Aug 11, 15:30
Claude    max   7-day window    [██░░░░░░░░]  17%  Aug 17, 08:59
Claude    max   7-day Fable     [█░░░░░░░░░]  13%  Aug 17, 08:59
```

`make test` is green as a whole and shellcheck on the new launcher reports a
subset of what `get-ai-usage` already reports. Nothing in Python changed in the
rebase, so the ruff status is unchanged from the last green CI run.

## Open questions

Both of the remaining ones are yours to call, and neither blocks a merge:

1. **Nix** — no `nix run .#cli` app, since I can't test the flake here and
   would rather not guess. You mentioned doing it in a follow-up commit, which
   suits me.
2. **The QML section above** — merge it, or tell me to drop it and add your own.

I also updated `docs/provider-contract.md` (the diagram has a third branch now)
and added a README section covering install, the flags, and the settings file —
that last part matters for anyone without a widget to write the config for them.
