### PR TITLE
fix(get-ai-usage): resolve symlinks before locating the package

### DIFF
--- a/package/contents/tools/sh/get-ai-usage
+++ b/package/contents/tools/sh/get-ai-usage
@@ -29,7 +29,19 @@ ALL_PROVIDERS="claude antigravity openai kiro mistral openrouter grok zai copilo
 # and history-io. Keep the inline fallback: this script's whole contract is to
 # degrade readably rather than fail opaquely, so a truncated install must not
 # turn into a bare "no such file" from the frontends.
-_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve through symlinks first: BASH_SOURCE reports the link, not its target,
+# so a symlink into ~/.local/bin would look for the package next to the link.
+# `readlink -f` is GNU-only, so walk the chain by hand.
+_src="${BASH_SOURCE[0]}"
+while [ -L "$_src" ]; do
+    _link_dir="$(cd "$(dirname "$_src")" && pwd)"
+    _src="$(readlink "$_src")"
+    case "$_src" in
+        /*) ;;
+        *) _src="$_link_dir/$_src" ;;
+    esac
+done
+_SH_DIR="$(cd "$(dirname "$_src")" && pwd)"
 if [ -r "$_SH_DIR/python-interp.sh" ]; then
     . "$_SH_DIR/python-interp.sh"
 else
@@ -95,7 +107,7 @@ fi
 # this script is tools/sh/get-ai-usage). `python3 -m aiusage` resolves the
 # module from cwd or PYTHONPATH, and Plasma's executable DataEngine sets
 # neither, so it must be exported explicitly here.
-PKG_TOOLS="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG_TOOLS="$(cd "$_SH_DIR/.." && pwd)"
 export PYTHONPATH="$PKG_TOOLS${PYTHONPATH:+:$PYTHONPATH}"
 
 # -B: never write __pycache__ into the installed plasmoid — `make pack` only


### PR DESCRIPTION
The launcher derives the package location from `BASH_SOURCE`, which reports the
path it was invoked as. Through a symlink that is the link itself, so
`PYTHONPATH` points at the link's directory instead of `contents/tools`:

```console
$ ln -s ~/src/kde-ai-usage/package/contents/tools/sh/get-ai-usage ~/.local/bin/get-ai-usage
$ get-ai-usage --provider kimi
/usr/bin/python3: No module named aiusage
```

**The widget is unaffected** — `main.qml`, `hyprland/shell.qml` and the tray
binary all invoke the script by its real path. It surfaces when someone links
the backend onto `PATH` to use it on its own, which the README invites by
documenting `get-ai-usage --provider …` as a thing you can run. The workaround
is a wrapper script that `exec`s the real path, which works but is a papercut.

## The change

Walk the symlink chain before resolving the directory, then reuse that result
for `PKG_TOOLS` rather than reading `BASH_SOURCE` a second time. `readlink -f`
would be shorter, but it is GNU-only and this launcher is careful about
portability elsewhere (the interpreter probing, the no-python3 fallback), so it
seemed wrong to introduce a coreutils dependency here.

Invocation by real path is byte-for-byte unchanged in behaviour.

## Verified

```console
# with the patch, through a symlink
$ /tmp/lk/get-ai-usage --provider kimi
{"schemaVersion":1,"updatedAt":1786226035,"active":"kimi","providers":[{"id":"kimi",…

# with the patch, by real path — unchanged
$ ./package/contents/tools/sh/get-ai-usage --provider kimi
{"schemaVersion":1,"updatedAt":1786226036,"active":"kimi","providers":[{"id":"kimi",…

# without the patch, same symlink
$ /tmp/lk/get-ai-usage --provider kimi
/usr/bin/python3: No module named aiusage
```

`./tests/get-ai-usage.test.sh` (244 checks) and `./tests/python-interp.test.sh`
both pass with the patch applied.

I have been running this change for a while in a terminal-only distribution of
the backend, where linking the tool onto `PATH` is the normal install path, so
it has had some real use beyond the test suite.

Independent of #10 — this applies to `master` on its own and does not touch
anything that PR changes.

`export-snapshot` and `history-io` share the same `BASH_SOURCE` pattern but are
internal helpers that nothing would sensibly symlink, so I left them alone
rather than widen the diff. Happy to include them if you would rather they were
consistent.
