### PR TITLE
fix(zai): treat nextResetTime as the absolute epoch it is

### DIFF
--- a/package/contents/tools/aiusage/normalize/zai.py
+++ b/package/contents/tools/aiusage/normalize/zai.py
@@ -2,6 +2,23 @@ import math
 
 from ..contract import flat_window, jround, monthly_window, num, pct_clamp, provider_base, provider_error
 
+# Anything at or above this, read as a duration, would be more than 31 years —
+# so it is an absolute epoch instead. Live z.ai responses put an absolute
+# millisecond timestamp in `nextResetTime`, despite the field name; treating it
+# as a duration and adding it to `now` produced reset dates in the 2080s, which
+# went unnoticed because the formatted string carries no year.
+_ABSOLUTE_MS_FLOOR = 1000000000000
+
+
+def _reset_at(value, now):
+    """Reset epoch in seconds from a value that may be absolute or relative."""
+    ms = num(value)
+    if ms <= 0:
+        return 0
+    if ms >= _ABSOLUTE_MS_FLOOR:
+        return math.floor(ms / 1000)
+    return math.floor(now + ms / 1000)
+
 
 def normalize_zai(raw):
     now = raw["now"]
@@ -22,9 +39,9 @@ def normalize_zai(raw):
     token_pct = pct_clamp(num(res.get("tokenPct")))
     token2_pct = pct_clamp(num(res.get("token2Pct")))
     tools_pct = pct_clamp(num(res.get("toolsPct")))
-    token_reset = math.floor(now + num(res.get("tokenResetMs")) / 1000) if num(res.get("tokenResetMs")) > 0 else 0
-    token2_reset = math.floor(now + num(res.get("token2ResetMs")) / 1000) if num(res.get("token2ResetMs")) > 0 else 0
-    tools_reset = math.floor(now + num(res.get("toolsResetMs")) / 1000) if num(res.get("toolsResetMs")) > 0 else 0
+    token_reset = _reset_at(res.get("tokenResetMs"), now)
+    token2_reset = _reset_at(res.get("token2ResetMs"), now)
+    tools_reset = _reset_at(res.get("toolsResetMs"), now)
     token_detail = (
         f"{num(res.get('tokenUsed'))} / {num(res.get('tokenLimit'))} tokens"
         if res.get("tokenUsed") is not None and res.get("tokenLimit") is not None

--- a/tests/fixtures/zai-absolute-reset.json
+++ b/tests/fixtures/zai-absolute-reset.json
@@ -1,0 +1,27 @@
+{
+  "id": "zai",
+  "now": 1785000000,
+  "inputs": {
+    "usage": {
+      "hasKey": true,
+      "keyValid": true,
+      "level": "pro",
+      "tokenPct": 39,
+      "tokenResetMs": 1785007200000,
+      "tokenUsed": 390,
+      "tokenLimit": 1000,
+      "token2Pct": 86,
+      "token2ResetMs": 1785086400000,
+      "toolsPct": 6,
+      "toolsRemaining": 931,
+      "toolsResetMs": 1786000000000,
+      "models": [
+        {
+          "modelCode": "glm-4.6",
+          "usage": 31
+        }
+      ]
+    },
+    "status": null
+  }
+}

--- a/tests/get-ai-usage.test.sh
+++ b/tests/get-ai-usage.test.sh
@@ -241,6 +241,15 @@ check zai-success "turns relative resets into absolute timestamps" '
     and .details.tools.resetAt == 1785007200 and .details.tools.remaining == 60
     and .historyValues == {za: 25}
     and .quotaWindows[0].detail == "250 / 1000 tokens"'
+# Live responses put an absolute millisecond epoch in nextResetTime, not a
+# duration. Adding that to `now` once produced reset dates decades out, which
+# the year-less formatting hid. Both shapes have to survive.
+check zai-absolute-reset "keeps an absolute reset epoch instead of adding it to now" '
+    .ok and .details.token.resetAt == 1785007200
+    and .details.tools.resetAt == 1786000000
+    and ([.quotaWindows[] | select(.key == "zai_tokens_long")] | first | .resetAt) == 1785086400'
+check zai-absolute-reset "resets stay within a plausible horizon of now" '
+    [.quotaWindows[].resetAt] | all(. == 0 or (. > 1785000000 and . < 1785000000 + 60 * 86400))'
 check zai-invalid-token "passes the token error through" '
     (.ok | not) and .error == "Z.AI: Invalid Z.AI token"'
 check zai-missing "reports an unconfigured token" '


### PR DESCRIPTION
Fixes #12.

`nextResetTime` carries an absolute millisecond epoch, and `normalize/zai.py`
adds it to `now`, which lands every Z.AI reset in the 2080s. The year-less
`reset_text` format hides it.

## The change

A value at or above `1e12` ms would be more than 31 years as a duration, so it
can only be a timestamp. Below that it is still treated as a duration, so a
response in the other shape — a different plan, a future API change — keeps
working instead of trading one wrong answer for another. I preferred that over
switching the interpretation outright, since I can only observe one account.

## Verified against the provider

Interpreted this way, the same account's windows become:

| window | computed | plausible for |
| --- | --- | --- |
| 5-hour tokens | Aug 9, 02:01 | a 5-hour window |
| 7-day tokens | Aug 9, 22:42 | a ~7-day window near its end |
| Monthly tools | Aug 21, 22:42 | a monthly quota |

and z.ai's own usage page for that account states a reset point of
**09.08.2026, 22:42** — the 7-day figure, exactly. Before the change the same
windows read "Mar 16", "Mar 17" and "Mar 29" — of 2083.

## Tests

`zai-success.json` is untouched and keeps its existing assertion, so the
relative-duration path stays covered. `zai-absolute-reset.json` adds the shape
real responses have, with two checks: the exact expected epochs, and — the one
that would have caught this in the first place — that every reset lands within a
plausible horizon of `now`.

`./tests/get-ai-usage.test.sh` passes (251 checks), as does the rest of
`make test`; ruff check and format are clean.

## Worth knowing

The existing fixture encodes the duration assumption rather than a recorded
response, which is why the suite confirmed the behaviour instead of testing it.
That is the sort of thing worth a second look elsewhere: the fixtures that were
hand-written from an assumption cannot fail in the way recorded ones can. I have
not audited the others.

Independent of #10 and #11 — this touches only `normalize/zai.py` and the
fixtures.
