### PR TITLE
fix(claude): keep a model-scoped week out of the account week

### DIFF
--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -156,7 +156,10 @@ needs in order to call the plan endpoints.
 
 **claude** — `hasOAuth`, `hasAdminKey`, `subscriptionType`, `rateLimitTier`,
 `organizationUuid`, `effortLevel`, `autoDream`, `session`/`weekly`
-(`available`, `pct`, `resetAt`, `tokensUsed`, `tokenLimit`), `extraTokens`,
+(`available`, `pct`, `resetAt`, `tokensUsed`, `tokenLimit`), `scopedWeekly`
+(one entry per `weekly_scoped` limit — a narrower week that runs alongside the
+all-models one, such as Fable; `key`, `label`, `model`, `available`, `pct`,
+`resetAt`, and a matching `quotaWindows` row), `extraTokens`,
 `extraUsage` (`enabled`, `limit`, `used`, `pct`, `currency`),
 `organizationUsage` (`models` keyed by model with `input_tokens`,
 `output_tokens`, `cost_usd`, `priced`, plus `totalInputTokens`,

--- a/package/contents/tools/aiusage/normalize/claude.py
+++ b/package/contents/tools/aiusage/normalize/claude.py
@@ -13,14 +13,49 @@ from ..contract import (
 from ..stats import claude_stats
 
 
+def scope_name(scope):
+    # A scoped limit names what it is narrowed to, either a model or a surface.
+    scope = scope if isinstance(scope, dict) else {}
+    model = scope.get("model")
+    model = model if isinstance(model, dict) else {}
+    name = str(model.get("display_name") or "").strip()
+    if name == "":
+        name = str(scope.get("surface") or "").strip()
+    return name
+
+
+def scoped_key(name):
+    slug = "".join(c if c.isalnum() else "_" for c in name.lower()).strip("_")
+    return "weekly_" + slug if slug else "weekly_scoped"
+
+
+def scoped_label(name):
+    # An unnamed scope still gets a row; "scoped" is vague but it is not a lie,
+    # and dropping the row would hide a budget that is being spent.
+    return "7-day " + name if name else "7-day scoped"
+
+
 def claude_windows(u):
     session = unavailable_window()
     weekly = unavailable_window()
+    scoped = []
     for i in u.get("limits") or []:
         group, kind = i.get("group"), i.get("kind")
         if group == "session" or kind == "session":
             session = window_value(i.get("percent"), i.get("resets_at"), i.get("is_active"))
-        if group == "weekly" or kind in ("weekly", "weekly_scoped"):
+        elif kind == "weekly_scoped":
+            # A scoped week is a second, narrower budget running alongside the
+            # all-models week, not a reading of it — Claude Code lists it as its
+            # own "Current week (<model>)" row. Folding it into `weekly` would
+            # report the model's percentage as the account's.
+            #
+            # It is read as active for the same reason the legacy windows below
+            # are: `is_active` marks which limit is currently binding, not
+            # whether the number is real, and a percentage that came back is a
+            # percentage worth showing. An inapplicable limit has no percent and
+            # still falls out as unavailable.
+            scoped.append((scope_name(i.get("scope")), window_value(i.get("percent"), i.get("resets_at"), True)))
+        elif group == "weekly" or kind in ("weekly", "weekly_all"):
             weekly = window_value(i.get("percent"), i.get("resets_at"), i.get("is_active"))
     if not session["available"] and u.get("five_hour") is not None:
         fh = u["five_hour"]
@@ -28,7 +63,7 @@ def claude_windows(u):
     if not weekly["available"] and u.get("seven_day") is not None:
         sd = u["seven_day"]
         weekly = window_value(sd.get("utilization"), sd.get("resets_at"), True)
-    return {"session": session, "weekly": weekly}
+    return {"session": session, "weekly": weekly, "scoped": scoped}
 
 
 def normalize_claude(raw):
@@ -57,6 +92,7 @@ def normalize_claude(raw):
         "organizationUsage": org,
         "stats": stats,
         "status": status,
+        "scopedWeekly": [],
     }
 
     if token == "":
@@ -114,7 +150,7 @@ def normalize_claude(raw):
     r["quotaWindows"] = [
         quota_window("session", "5-hour session", w["session"], s_detail),
         quota_window("weekly", "7-day window", w["weekly"], w_detail),
-    ]
+    ] + [quota_window(scoped_key(name), scoped_label(name), win, "") for name, win in w["scoped"] if win["available"]]
     r["slots"] = [
         {
             "pct": w["session"]["pct"],
@@ -142,6 +178,9 @@ def normalize_claude(raw):
         **base_details,
         "session": {**w["session"], "tokensUsed": s_tokens, "tokenLimit": s_limit},
         "weekly": {**w["weekly"], "tokensUsed": w_tokens, "tokenLimit": w_limit},
+        "scopedWeekly": [
+            {"key": scoped_key(name), "label": scoped_label(name), "model": name, **win} for name, win in w["scoped"] if win["available"]
+        ],
         "extraTokens": extra_tokens,
         "extraUsage": {
             "enabled": extra_usage.get("is_enabled") is True,

--- a/tests/fixtures/claude-scoped-week.json
+++ b/tests/fixtures/claude-scoped-week.json
@@ -1,0 +1,119 @@
+{
+  "id": "claude",
+  "now": 1786439700,
+  "inputs": {
+    "credentials": {
+      "claudeAiOauth": {
+        "accessToken": "sk-oauth-secret",
+        "subscriptionType": "max",
+        "rateLimitTier": "default_max_20x"
+      }
+    },
+    "usage": {
+      "five_hour": {
+        "utilization": 9.0,
+        "resets_at": "2026-08-11T13:30:00.622724+00:00",
+        "limit_dollars": null,
+        "used_dollars": null,
+        "remaining_dollars": null
+      },
+      "seven_day": {
+        "utilization": 17.0,
+        "resets_at": "2026-08-17T06:59:59.622750+00:00",
+        "limit_dollars": null,
+        "used_dollars": null,
+        "remaining_dollars": null
+      },
+      "seven_day_oauth_apps": null,
+      "seven_day_opus": null,
+      "seven_day_sonnet": null,
+      "seven_day_cowork": null,
+      "seven_day_omelette": null,
+      "tangelo": null,
+      "iguana_necktie": null,
+      "omelette_promotional": null,
+      "nimbus_quill": {
+        "utilization": 0.0,
+        "resets_at": null,
+        "limit_dollars": null,
+        "used_dollars": null,
+        "remaining_dollars": null
+      },
+      "cinder_cove": null,
+      "amber_ladder": null,
+      "extra_usage": {
+        "is_enabled": false,
+        "monthly_limit": null,
+        "used_credits": null,
+        "utilization": null,
+        "currency": null,
+        "decimal_places": null,
+        "disabled_reason": null,
+        "user_disabled": true,
+        "spend_limit_reached": false,
+        "credits_ever_enabled": true,
+        "daily": null,
+        "weekly": null
+      },
+      "limits": [
+        {
+          "kind": "session",
+          "group": "session",
+          "percent": 9,
+          "severity": "normal",
+          "resets_at": "2026-08-11T13:30:00.622724+00:00",
+          "scope": null,
+          "is_active": false
+        },
+        {
+          "kind": "weekly_all",
+          "group": "weekly",
+          "percent": 17,
+          "severity": "normal",
+          "resets_at": "2026-08-17T06:59:59.622750+00:00",
+          "scope": null,
+          "is_active": true
+        },
+        {
+          "kind": "weekly_scoped",
+          "group": "weekly",
+          "percent": 13,
+          "severity": "normal",
+          "resets_at": "2026-08-17T06:59:59.623033+00:00",
+          "scope": {
+            "model": {
+              "id": null,
+              "display_name": "Fable"
+            },
+            "surface": null
+          },
+          "is_active": false
+        }
+      ],
+      "spend": {
+        "used": {
+          "amount_minor": 0,
+          "currency": "USD",
+          "exponent": 2
+        },
+        "limit": null,
+        "percent": 0,
+        "severity": "normal",
+        "enabled": false,
+        "disabled_reason": null,
+        "cap": null,
+        "balance": null,
+        "auto_reload": null,
+        "disclaimer": "Usage credits cover you when you hit your plan limits. [Learn more](https://support.claude.com/articles/12429409)",
+        "can_purchase_credits": false,
+        "can_toggle": false
+      },
+      "member_dashboard_available": false
+    },
+    "usageError": "",
+    "orgUsage": null,
+    "settings": {},
+    "stats": {},
+    "status": null
+  }
+}

--- a/tests/fixtures/claude-success.json
+++ b/tests/fixtures/claude-success.json
@@ -22,9 +22,16 @@
         },
         {
           "group": "weekly",
-          "kind": "weekly_scoped",
+          "kind": "weekly_all",
           "is_active": true,
           "percent": 61,
+          "resets_at": "2026-07-25T15:00:00Z"
+        },
+        {
+          "group": "weekly",
+          "kind": "weekly_scoped",
+          "is_active": true,
+          "percent": 44,
           "resets_at": "2026-07-25T15:00:00Z"
         }
       ],

--- a/tests/get-ai-usage.test.sh
+++ b/tests/get-ai-usage.test.sh
@@ -70,6 +70,19 @@ check claude-success "prefers semantic limits over legacy windows" '
     and .historyValues == {s: 23, w: 61}'
 check claude-success "formats the session window for the panel" '
     (.quotaWindows[0] | .key == "session" and .available and .detail == "120000 / 500000 tokens")'
+check claude-success "keeps a scoped week out of the account week" '
+    .details.weekly.pct == 61
+    and (.details.scopedWeekly | length) == 1
+    and (.details.scopedWeekly[0] | .pct == 44 and .model == "" and .label == "7-day scoped")'
+check claude-scoped-week "reads the account week and the per-model week apart" '
+    .ok and .details.session.pct == 9 and .details.weekly.pct == 17
+    and (.details.scopedWeekly | length) == 1
+    and (.details.scopedWeekly[0] | .pct == 13 and .model == "Fable"
+         and .key == "weekly_fable" and .label == "7-day Fable"
+         and .resetAt == 1786949999)'
+check claude-scoped-week "shows a scoped week that is not the binding limit" '
+    (.quotaWindows | map(.key)) == ["session", "weekly", "weekly_fable"]
+    and (.quotaWindows[2] | .available and .pct == 13 and .label == "7-day Fable")'
 check claude-success "reports credential presence, not values" '
     .details.hasOAuth == true and .details.hasAdminKey == true
     and .details.subscriptionType == "max" and .details.organizationUuid == "org-1234"'


### PR DESCRIPTION
## What

Claude's `/api/oauth/usage` returns two weekly limits: the account-wide one and,
for accounts that have them, a narrower per-model one. Right now the second is
never shown, and it corrupts the first on the way past.

A live response (Max account, redacted only in the credential envelope):

```json
"limits": [
  {"kind": "session",       "group": "session", "percent": 9,  "is_active": false},
  {"kind": "weekly_all",    "group": "weekly",  "percent": 17, "is_active": true},
  {"kind": "weekly_scoped", "group": "weekly",  "percent": 13, "is_active": false,
   "scope": {"model": {"display_name": "Fable"}}}
]
```

`claude_windows()` matched `group == "weekly"` for both, so the scoped entry
overwrote the account one. The scoped percentage itself was dropped.

## Why the suite never caught it

Two things hid it:

1. `window_value()` discards anything with `is_active: false`, so the overwrite
   produced *unavailable* rather than a wrong number, and the
   `five_hour`/`seven_day` fallback quietly restored a correct weekly figure.
   The output looked right by accident.
2. `claude-success.json` asserted that `weekly_scoped` **is** the weekly window
   — it was the only weekly entry in the fixture. That was written from the
   assumption rather than recorded from a response, so the test confirmed the
   bug instead of finding it. (Same shape of mistake as the one in #9's
   fixture, which is why I went looking.)

The accident only holds while the scoped limit is not the binding one. Once it
is (`is_active: true`), the weekly row reports the *model's* percentage as the
account's.

## How Claude Code reads the same payload

Rather than guess at `is_active`, I checked the client. Claude Code builds its
`/usage` panel as:

```js
[{title: "Current session",           limit: t.five_hour},
 {title: "Current week (all models)", limit: t.seven_day},
 ...(isMax ? [{title: "Current week (Sonnet only)", limit: t.seven_day_sonnet}] : []),
 ...fromLimits(t.limits)]
```

where `fromLimits` filters `kind === "weekly_scoped" && scope?.model` and emits
one `Current week (<display_name>)` row each — **without** consulting
`is_active`. So `is_active` marks which limit is currently *binding*, not
whether the number is real. An inapplicable limit carries no `percent` and
still falls out as unavailable.

## Change

Scoped limits get their own `quotaWindows` row and a `details.scopedWeekly`
entry, labelled from `scope.model.display_name`, falling back to
`scope.surface` and then to a plain `"scoped"` — an unnamed scope still gets a
row rather than being hidden, since it is a budget being spent either way.

Nothing is removed from the contract. `slots`, `chartWindows` and
`historyValues` are untouched, so the **Plasma widget renders exactly as
before** (it does not read `quotaWindows`), and the **Quickshell shell** picks
the new row up on its own, since `AiUsageShell.qml` repeats over
`quotaWindows`.

## Tests

- `claude-success.json` now carries `weekly_all` **plus** an unnamed scoped
  entry, which guards against the overwrite returning.
- `claude-scoped-week.json` is a **recorded** response covering the named case.
- Three new assertions: the account week survives a scoped one, the per-model
  week is read apart from it, and a scoped week shows even when it is not the
  binding limit.

`make test` green (252 backend checks, 12 node tests), `make lint-py` clean.

Verified against the account's own usage page, which reports Fable at 13%
resetting Mon 08:59 — the figures the backend now returns.
