### PR TITLE
feat(zai): report today's token consumption beside the quota windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A KDE Plasma 6 panel widget for tracking AI API quota usage across multiple serv
 | Kiro | Monthly credits, remaining balance, reset date, overage, and inferred plan | Supported |
 | Mistral AI | Key status, available models, and local vibe CLI cost/token statistics | Supported |
 | OpenRouter | Spend, credit limit, usage percentage, and account label | Untested |
-| Z.AI | 5-hour token quota, monthly tools quota, reset countdowns, and model details | Untested |
+| Z.AI | 5-hour token quota, monthly tools quota, reset countdowns, model details, and today's token consumption | Untested |
 | GitHub Copilot | Monthly premium request usage against a configurable quota | Personal billing supported; organization/enterprise billing not yet supported |
 | DeepSeek | Available balance with granted and topped-up breakdown | Untested |
 | Kimi / Moonshot AI | Available balance with voucher and cash breakdown | Untested |

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -88,7 +88,8 @@ when its remembered one disappears.
 | `summary.text` | headline string, already formatted (`"23%"`, `"$12.5"`, `"CLI"`) |
 | `summary.detail` | plan / account line |
 | `summary.hasChart` | false when the provider has no series worth charting |
-| `quotaWindows[]` | ordered rows: `key`, `label`, `pct`, `available`, `resetAt`, `resetText`, `detail`, `showMeter` |
+| `quotaWindows[]` | ordered rows: `key`, `label`, `pct`, `available`, `resetAt`, `resetText`, `detail`, `showMeter`, and optionally `note` |
+| `note` | aside shown beside the value. Only meaningful with `showMeter: false`, where `detail` becomes the value itself and would otherwise leave the row no room for context. Optional — a frontend that ignores it loses the aside, nothing else |
 | `chartWindows[]` | chart ranges — see below. Empty when the provider has no chartable series |
 | `slots[]` | compact panel pills: `pct`, `color`, `text` (null → show the meter), `tooltip` |
 | `historyValues` | series keys this provider contributes to the shared usage history |
@@ -195,7 +196,22 @@ rollout), `status`.
 `billingError`.
 
 **zai** — `hasKey`, `keyValid`, `level`, `token` (`pct`, `used`, `limit`,
-`resetAt`), `tools` (`pct`, `remaining`, `resetAt`), `models`.
+`resetAt`), `tokenLong` (`pct`, `resetAt`), `tools` (`pct`, `remaining`,
+`resetAt`), `models`, `today` (`available`, `date`, `rollsOverAt`, `tokens`,
+`calls`, `models[]` with `name`/`tokens`, `tools` with `search`/`reader`/
+`zread`).
+
+`today` comes from two further monitor endpoints, `model-usage` and
+`tool-usage`, both taking `startTime`/`endTime` in `yyyy-MM-dd HH:mm:ss` —
+they reject ISO-8601 with a `T`. The bounds are the plain **local calendar
+date**, sent without timezone conversion, because that is what the vendor's
+dashboard does and matching it is the whole point of the figure (verified
+digit-for-digit against a live account). The service applies those bounds on
+its own clock, which runs ahead of Europe, so the day being summed is shifted
+and the total stops growing before local midnight; `rollsOverAt` carries the
+date change so a total that has stopped moving does not read as stuck. Neither
+call can fail the provider: the quota windows are the point, and a missing
+statistic must not cost them.
 
 **copilot** — `hasKey`, `keyValid`, `username`, `used`, `quota`, `pct`,
 `resetAt`.

--- a/package/contents/tools/aiusage/contract.py
+++ b/package/contents/tools/aiusage/contract.py
@@ -138,8 +138,8 @@ def quota_window(key, label, w, detail):
     }
 
 
-def flat_window(key, label, pct, reset_at, detail, meter):
-    return {
+def flat_window(key, label, pct, reset_at, detail, meter, note=""):
+    w = {
         "key": key,
         "label": label,
         "pct": pct_clamp(pct),
@@ -149,6 +149,12 @@ def flat_window(key, label, pct, reset_at, detail, meter):
         "detail": detail,
         "showMeter": meter,
     }
+    if note:
+        # A meterless row spends `detail` on the value itself, leaving nothing
+        # beside it. `note` is the aside such a row would otherwise have to
+        # cram into the value.
+        w["note"] = note
+    return w
 
 
 def chart_window(id_, key, label, size, gran):

--- a/package/contents/tools/aiusage/normalize/zai.py
+++ b/package/contents/tools/aiusage/normalize/zai.py
@@ -1,3 +1,4 @@
+import datetime
 import math
 
 from ..contract import flat_window, jround, monthly_window, num, pct_clamp, provider_base, provider_error
@@ -8,6 +9,43 @@ from ..contract import flat_window, jround, monthly_window, num, pct_clamp, prov
 # as a duration and adding it to `now` produced reset dates in the 2080s, which
 # went unnoticed because the formatted string carries no year.
 _ABSOLUTE_MS_FLOOR = 1000000000000
+
+
+def _compact(n):
+    """Token counts run to eight digits; the table has room for a few.
+
+    Two decimals to match how the vendor's dashboard prints the same figure —
+    this number exists to be checked against that page, and a differently
+    rounded one invites the reader to wonder which is wrong.
+    """
+    n = num(n)
+    for limit, suffix in ((1000000000, "B"), (1000000, "M"), (1000, "K")):
+        if abs(n) >= limit:
+            return f"{n / limit:.2f}{suffix}"
+    return str(int(n))
+
+
+def _today_label(today):
+    """ "Today (Aug 12)" — the reset column already carries the date this rolls
+    over to, and a bare "Today" next to tomorrow's date reads as a mismatch.
+    Naming the day being summed removes the question."""
+    date = str(today.get("date") or "")
+    try:
+        d = datetime.datetime.strptime(date, "%Y-%m-%d")
+    except ValueError:
+        return "Today"
+    return "Today (" + d.strftime("%b ") + str(d.day) + ")"
+
+
+def _today_detail(today):
+    """The value itself: "41.18M tokens", or "" if it did not come back."""
+    return f"{_compact(today['tokens'])} tokens" if today.get("tokens") is not None else ""
+
+
+def _today_note(today):
+    """The aside: "370 calls". Tokens are what the quota is spent in, so they
+    are the value; the call count is context for it."""
+    return f"{num(today['calls'])} calls" if today.get("calls") is not None else ""
 
 
 def _reset_at(value, now):
@@ -51,11 +89,22 @@ def normalize_zai(raw):
 
     r = provider_base("zai", "Z.AI", "#126ef4", now)
     r["summary"] = {"pct": token_pct, "text": f"{jround(token_pct)}%", "detail": res.get("level") or "", "hasChart": True}
+    today = res.get("today") if isinstance(res.get("today"), dict) else None
+    today_detail = _today_detail(today) if today else ""
+
     r["quotaWindows"] = [
         flat_window("zai_tokens", "5-hour tokens", token_pct, token_reset, token_detail, True),
         flat_window("zai_tokens_long", "7-day tokens", token2_pct, token2_reset, "", True),
         flat_window("zai_tools", "Monthly tools", tools_pct, tools_reset, tools_detail, True),
     ]
+    if today_detail:
+        # Consumption so far, not a share of anything, so it carries a value
+        # instead of a meter. The reset column holds the date change, so a
+        # total that has stopped growing (see _report_day) has a visible
+        # horizon instead of looking stuck.
+        r["quotaWindows"].append(
+            flat_window("zai_today", _today_label(today), 0, num(today.get("rollsOverAt")), today_detail, False, note=_today_note(today))
+        )
     r["slots"] = [
         {"pct": token_pct, "color": "#126ef4", "text": None, "tooltip": f"Z.AI tokens (5h): {jround(token_pct)}%"},
         {"pct": token2_pct, "color": "#3b82f6", "text": None, "tooltip": f"Z.AI tokens (7d): {jround(token2_pct)}%"},
@@ -83,5 +132,16 @@ def normalize_zai(raw):
             "resetAt": tools_reset,
         },
         "models": res.get("models") or [],
+        "today": {
+            "available": today is not None,
+            "date": (today or {}).get("date") or "",
+            "rollsOverAt": num((today or {}).get("rollsOverAt")),
+            "tokens": num((today or {}).get("tokens")) if (today or {}).get("tokens") is not None else None,
+            "calls": num((today or {}).get("calls")) if (today or {}).get("calls") is not None else None,
+            "models": [
+                {"name": m.get("name") or "", "tokens": num(m.get("tokens"))} for m in ((today or {}).get("models") or []) if isinstance(m, dict)
+            ],
+            "tools": (today or {}).get("tools") or {},
+        },
     }
     return r

--- a/package/contents/tools/aiusage/providers/zai.py
+++ b/package/contents/tools/aiusage/providers/zai.py
@@ -3,9 +3,90 @@
 Ported from tools/sh/get-zai-usage.
 """
 
+import datetime
 import os
 
 from ..http import as_json, error_json, fetch_json, http_error_json, resolve_key
+
+# The API rejects ISO-8601 with a "T" separator by name, asking for this.
+_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def _report_day():
+    """Today's date as the API wants it, plus the epoch at which it changes.
+
+    The bounds are the plain local calendar date, deliberately sent without
+    timezone conversion — that is what the vendor's own dashboard does, and
+    matching it is the point of the figure. Verified against a live account:
+    the string "2026-08-11" returned 41,175,632 tokens with a per-model split
+    of 36.11M / 5.06M / 2.41K, which is what the dashboard showed for that day
+    down to the last digit.
+
+    The service applies those bounds on its own clock, which runs ahead of
+    Europe, so the day being summed is shifted by some hours and the total
+    stops growing before local midnight. That shift is the vendor's, not ours;
+    converting it away would produce a number the account holder cannot find
+    anywhere.
+    """
+    today = datetime.date.today()
+    start = datetime.datetime.combine(today, datetime.time(0, 0, 0))
+    end = datetime.datetime.combine(today, datetime.time(23, 59, 59))
+    rolls_over = datetime.datetime.combine(today + datetime.timedelta(days=1), datetime.time(0, 0, 0))
+    return start.strftime(_TIME_FORMAT), end.strftime(_TIME_FORMAT), int(rolls_over.timestamp())
+
+
+def _fetch_window(path, api_key, start, end, fixture_env):
+    """One monitor time-series call. Returns its `data` object, or None."""
+    from urllib.parse import quote
+
+    result = fetch_json(
+        f"https://api.z.ai/api/monitor/usage/{path}?startTime={quote(start)}&endTime={quote(end)}",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+            "User-Agent": "kde-ai-usage/zai",
+        },
+        timeout=10,
+        fixture_path=os.environ.get(fixture_env),
+    )
+    if result.status != 200:
+        return None
+    body = as_json(result.body)
+    if not isinstance(body, dict) or body.get("success") is not True:
+        return None
+    data = body.get("data")
+    return data if isinstance(data, dict) else None
+
+
+def _today_usage(api_key):
+    """Today's totals, or None. Never raises the caller's failure mode: the
+    quota windows are the point of this provider, and losing an extra
+    statistic must not cost us those."""
+    start, end, rolls_over = _report_day()
+    models = _fetch_window("model-usage", api_key, start, end, "ZAI_MODEL_USAGE_RESPONSE_FILE")
+    tools = _fetch_window("tool-usage", api_key, start, end, "ZAI_TOOL_USAGE_RESPONSE_FILE")
+    if models is None and tools is None:
+        return None
+
+    totals = (models or {}).get("totalUsage") or {}
+    tool_totals = (tools or {}).get("totalUsage") or {}
+    summary = (models or {}).get("modelSummaryList")
+    return {
+        "date": start[:10],
+        "rollsOverAt": rolls_over,
+        "tokens": totals.get("totalTokensUsage"),
+        "calls": totals.get("totalModelCallCount"),
+        "models": [
+            {"name": m.get("modelName") or "", "tokens": m.get("totalTokens")}
+            for m in (summary if isinstance(summary, list) else [])
+            if isinstance(m, dict)
+        ],
+        "tools": {
+            "search": tool_totals.get("totalNetworkSearchCount"),
+            "reader": tool_totals.get("totalWebReadMcpCount"),
+            "zread": tool_totals.get("totalZreadMcpCount"),
+        },
+    }
 
 
 def get_zai_usage():
@@ -59,5 +140,6 @@ def get_zai_usage():
             "toolsRemaining": tools.get("remaining"),
             "toolsResetMs": tools.get("nextResetTime"),
             "models": tools.get("usageDetails") or [],
+            "today": _today_usage(api_key),
         }
     return {"hasKey": True, "keyValid": False, "error": "Z.AI unexpected response"}

--- a/tests/fixtures/zai-today.json
+++ b/tests/fixtures/zai-today.json
@@ -1,0 +1,58 @@
+{
+  "id": "zai",
+  "now": 1786440000,
+  "inputs": {
+    "usage": {
+      "hasKey": true,
+      "keyValid": true,
+      "level": "pro",
+      "tokenPct": 48,
+      "tokenResetMs": 1786472953562,
+      "token2Pct": 17,
+      "token2ResetMs": 1786912954987,
+      "toolsPct": 0,
+      "toolsRemaining": 1000,
+      "toolsResetMs": 1787344954972,
+      "models": [
+        {
+          "modelCode": "search-prime",
+          "usage": 0
+        },
+        {
+          "modelCode": "web-reader",
+          "usage": 0
+        },
+        {
+          "modelCode": "zread",
+          "usage": 0
+        }
+      ],
+      "today": {
+        "date": "2026-08-11",
+        "rollsOverAt": 1786485600,
+        "tokens": 41175632,
+        "calls": 370,
+        "models": [
+          {
+            "name": "GLM-5.2",
+            "tokens": 36114679
+          },
+          {
+            "name": "GLM-5-Turbo",
+            "tokens": 5058547
+          },
+          {
+            "name": "GLM-4.7",
+            "tokens": 2406
+          }
+        ],
+        "tools": {
+          "search": 0,
+          "reader": 0,
+          "zread": 0
+        }
+      }
+    },
+    "status": null
+  }
+}

--- a/tests/get-ai-usage.test.sh
+++ b/tests/get-ai-usage.test.sh
@@ -263,6 +263,26 @@ check zai-absolute-reset "keeps an absolute reset epoch instead of adding it to 
     and ([.quotaWindows[] | select(.key == "zai_tokens_long")] | first | .resetAt) == 1785086400'
 check zai-absolute-reset "resets stay within a plausible horizon of now" '
     [.quotaWindows[].resetAt] | all(. == 0 or (. > 1785000000 and . < 1785000000 + 60 * 86400))'
+# The monitor endpoints report consumption, not a share of a quota, so the
+# row carries a value instead of a meter and is ruled off from the windows.
+check zai-today "reports the service day total beside the quota windows" '
+    .ok and .details.today.available
+    and .details.today.tokens == 41175632 and .details.today.calls == 370
+    and .details.today.date == "2026-08-11"
+    and (.details.today.models | map(.name)) == ["GLM-5.2", "GLM-5-Turbo", "GLM-4.7"]'
+check zai-today "renders the day total as a value, not a meter" '
+    (.quotaWindows | map(.key)) == ["zai_tokens", "zai_tokens_long", "zai_tools", "zai_today"]
+    and (.quotaWindows[3] | .detail == "41.18M tokens" and .note == "370 calls"
+         and (.showMeter | not) and .resetAt == 1786485600)'
+# The reset column shows the date this rolls over TO, so the label has to name
+# the day being summed — otherwise the row reads as being about tomorrow.
+check zai-today "names the day it is summing" '
+    (.quotaWindows[3].label) == "Today (Aug 11)"'
+# A day total that has stopped growing would read as a stuck counter, so the
+# date change is carried rather than left to the reader to work out.
+check zai-success "stays silent about a day total that was not fetched" '
+    (.details.today.available | not)
+    and ([.quotaWindows[] | select(.key == "zai_today")] | length) == 0'
 check zai-invalid-token "passes the token error through" '
     (.ok | not) and .error == "Z.AI: Invalid Z.AI token"'
 check zai-missing "reports an unconfigured token" '


### PR DESCRIPTION
## Why

Z.AI exposes two monitor endpoints beyond the quota one this repo already
calls, and they carry the daily consumption its own dashboard shows:

```
GET /api/monitor/usage/model-usage?startTime=…&endTime=…
GET /api/monitor/usage/tool-usage?startTime=…&endTime=…
```

Same bearer auth as `quota/limit`, no extra credential. They give the provider
a `Today` row with the token total and call count, plus a per-model split and
the search/reader/zread counts in `details.today`.

Neither call may fail the provider — the quota windows are the point of it, and
losing an extra statistic must not cost them. Both are best-effort and leave the
windows untouched on error.

## Three undocumented things, each of which cost a wrong result first

These are the reason this PR is worth more than its diff, so they are in the
commit message and the contract doc rather than only here.

**Time format.** `yyyy-MM-dd HH:mm:ss`. ISO-8601 with a `T` is rejected by name
(`"incorrect time format"`).

**Send the local calendar date, do not convert it.** The response's hour axis
runs on the service clock, which is ahead of Europe — verified by requesting a
day that had not started locally yet and getting back the hour in progress
there. It is tempting to conclude the bounds must be built in that zone. They
must not: the vendor dashboard sends the plain local date and labels the result
"today", so converting produces a figure the account holder cannot find on any
page. I got this wrong first and showed 11.2M against the dashboard's 41.18M.

Worth repeating on any change here: the string `2026-08-11` returned 41,175,632
tokens split 36,114,679 / 5,058,547 / 2,406 — matching the dashboard's
"41.18M / 36.11M / 5.06M / 2.41K" to the last digit. A second check over seven
days matched as well.

**Granularity switches at nine days.** Up to eight days the response is hourly,
from nine it is daily. Measured across 7/8/9/10/15/30 days. Worth stating
because the first probe here used exactly eight days — the last hourly case —
and concluded the API never aggregates, which is wrong.

One consequence is user-visible: because the bounds are applied on the service
clock, the day total stops growing before local midnight and only turns over
then. Without a stated horizon that reads as a stuck counter, so the row names
the day it is summing and `details.today.rollsOverAt` carries the date change.

## `note` on a quota window

A row with `showMeter: false` spends `detail` on the value itself, so it has
nowhere left to put context. The day total wants to read

```
Today (Aug 12)   44.44M tokens   262 calls
```

with the count beside the value rather than crammed into it. `note` is an
optional string on a `quotaWindows[]` entry for exactly that. A frontend that
ignores it loses the aside and nothing else: the Plasma widget does not read
`quotaWindows` at all, and the Quickshell panel repeats over it unchanged.

An earlier draft used a separator rule between the quota windows and such a
row instead. It was built, then dropped — it read as heavier than the
distinction warranted.

## Relationship to #10

Independent, and deliberately so. This PR does not touch `render.py`,
`cli.py` or the CLI test — the only overlap with #10 is `README.md` and
`docs/provider-contract.md`, and git merges both automatically. I verified that
by applying this branch on top of the #10 branch: no conflicts, and the full
suite green on the combination (268 + 262 checks). **They can be merged in
either order.**

The one piece held back is the five lines in `render.py` that display `note`,
since that file only exists in #10. If you merge that PR, the follow-up is nine
lines including its test; if you don't, nothing here breaks — the `Today` row
still reaches the Hyprland panel, and `note` simply goes unread.

## Tests

The backend suite goes from 259 to 268 checks. The fixture
`tests/fixtures/zai-today.json` is **recorded, not hand-written** — the last two
bugs I sent you here were both encoded in hand-written fixtures that asserted
the wrong behaviour and therefore confirmed the bug instead of catching it, so
this one is a captured response with the credential stripped.

Also documents `tokenLong` in the contract, which has been in the code since #9
but not in the doc.
