### PR TITLE
fix(http): strip credentials taken from the environment

### DIFF
--- a/hyprland/KeyField.qml
+++ b/hyprland/KeyField.qml
@@ -53,7 +53,11 @@ RowLayout {
                 background: null
                 selectByMouse: true
                 onTextEdited: {
-                    keyRow.shell.setSetting("keys", keyRow.settingKey, text);
+                    // Store trimmed: a pasted key often carries a trailing
+                    // space or newline. The field itself is left alone — this
+                    // fires while typing, and rewriting the text would move the
+                    // cursor mid-edit.
+                    keyRow.shell.setSetting("keys", keyRow.settingKey, String(text).trim());
                     refreshDebounce.restart();
                 }
             }

--- a/package/contents/tools/aiusage/http.py
+++ b/package/contents/tools/aiusage/http.py
@@ -20,10 +20,16 @@ class HttpResult:
 def resolve_key(widget_var, env_var, *files):
     """Credential precedence, identical for every provider: the value the
     widget passed in, then a conventional environment variable, then the
-    first readable config file."""
-    value = os.environ.get(widget_var, "")
+    first readable config file.
+
+    Environment values are stripped like the file ones: a credential pasted
+    with a trailing newline would otherwise reach urllib, which rejects the
+    header with a ValueError — and that exception carries the credential into
+    the traceback, defeating the guarantee that no secret leaves this package.
+    """
+    value = os.environ.get(widget_var, "").strip()
     if not value and env_var:
-        value = os.environ.get(env_var, "")
+        value = os.environ.get(env_var, "").strip()
     if not value:
         for path in files:
             if not path or not os.path.isfile(path):

--- a/package/contents/ui/KeyRow.qml
+++ b/package/contents/ui/KeyRow.qml
@@ -54,24 +54,33 @@ RowLayout {
             return "";
         }
         onEditingFinished: {
+            // A key is pasted, never typed, and a paste out of a browser or a
+            // password manager often carries a trailing space or newline. Trim
+            // once here, the same way the Python interpreter field does, so the
+            // stored value is the one the user meant — and write it back to the
+            // field, so what is shown is what was saved.
+            var val = String(text).trim();
+            if (val !== text)
+                text = val;
+
             if (kr.configKey === "claudeAdminApiKey")
-                Plasmoid.configuration.claudeAdminApiKey = text;
+                Plasmoid.configuration.claudeAdminApiKey = val;
             if (kr.configKey === "openaiApiKey")
-                Plasmoid.configuration.openaiApiKey = text;
+                Plasmoid.configuration.openaiApiKey = val;
             if (kr.configKey === "mistralApiKey")
-                Plasmoid.configuration.mistralApiKey = text;
+                Plasmoid.configuration.mistralApiKey = val;
             if (kr.configKey === "openrouterApiKey")
-                Plasmoid.configuration.openrouterApiKey = text;
+                Plasmoid.configuration.openrouterApiKey = val;
             if (kr.configKey === "grokApiKey")
-                Plasmoid.configuration.grokApiKey = text;
+                Plasmoid.configuration.grokApiKey = val;
             if (kr.configKey === "zaiToken")
-                Plasmoid.configuration.zaiToken = text;
+                Plasmoid.configuration.zaiToken = val;
             if (kr.configKey === "githubToken")
-                Plasmoid.configuration.githubToken = text;
+                Plasmoid.configuration.githubToken = val;
             if (kr.configKey === "deepseekApiKey")
-                Plasmoid.configuration.deepseekApiKey = text;
+                Plasmoid.configuration.deepseekApiKey = val;
             if (kr.configKey === "moonshotApiKey")
-                Plasmoid.configuration.moonshotApiKey = text;
+                Plasmoid.configuration.moonshotApiKey = val;
         }
     }
     QQC2.ToolButton {

--- a/tests/get-ai-usage.test.sh
+++ b/tests/get-ai-usage.test.sh
@@ -408,6 +408,30 @@ if ! printf '%s' "$defaults" | jq -e '(.providers | length) == 0 and .active == 
     failures=$((failures + 1))
 fi
 
+# ── Credentials from the environment are stripped ───────────────────────────
+# A token pasted into the widget's settings field with a trailing newline is
+# passed straight through as WIDGET_*. urllib rejects such a header value with
+# a ValueError whose message contains the credential, so an unstripped value
+# both breaks the provider and prints the secret in the traceback. Tested here
+# rather than through a provider call: a fixture returns before the header is
+# built, so only resolve_key itself can show the difference.
+# shellcheck source=../package/contents/tools/sh/python-interp.sh
+. "$ROOT/package/contents/tools/sh/python-interp.sh"
+if py_resolve; then
+    checks=$((checks + 1))
+    # $'…' keeps the newline: command substitution would strip it and the case
+    # under test would silently disappear.
+    stripped="$(WIDGET_TEST_KEY=$'secret-value\n' \
+        PYTHONPATH="$ROOT/package/contents/tools" "$PY" -c '
+from aiusage.http import resolve_key
+print(repr(resolve_key("WIDGET_TEST_KEY", "", )))
+')"
+    if [ "$stripped" != "'secret-value'" ]; then
+        printf 'FAIL: a trailing newline must not survive into a credential\n  got: %s\n' "$stripped" >&2
+        failures=$((failures + 1))
+    fi
+fi
+
 if [ "$failures" -ne 0 ]; then
     printf '%d of %d checks failed\n' "$failures" "$checks" >&2
     exit 1


### PR DESCRIPTION
Found while looking at #16. It is **not** the cause of that report — I say so
there — but it is a real bug in the same code path, and it leaks a credential.

## What happens

A token pasted into the widget's settings field with a trailing newline reaches
the backend unchanged. urllib then refuses to build the header:

```
ValueError: Invalid header value b'Bearer <the actual token>\n'
```

Two consequences. The provider fails with no JSON at all rather than a contract
error envelope, so a frontend sees a parse failure instead of a readable state.
And the exception message carries the credential into the traceback — which
goes against the rule the contract states explicitly, and that
`tests/get-ai-usage.test.sh` otherwise enforces, that no secret can appear in
any output.

The file path already normalises whitespace:

```python
value = f.read().translate(str.maketrans("", "", "\n\r ")).strip()
```

The environment path did not. This makes the two consistent.

## Why the test looks the way it does

It calls `resolve_key` directly instead of going through a provider, because a
`*_RESPONSE_FILE` fixture returns from `fetch_json` *before* the header is
built — a fixture-based test cannot see this bug at all, and a non-fixture one
would need the network.

It also uses `$'secret-value\n'` rather than `"$(printf 'secret-value\n')"`.
That matters: command substitution strips trailing newlines, so the first
version of this test passed against the unfixed code. I checked it fails
without the fix before trusting it:

```
FAIL: a trailing newline must not survive into a credential
  got: 'secret-value\n'
1 of 269 checks failed
```

With the fix, 269 pass, and the full suite is green (269 + 264). Verified
end-to-end too: a real token with a trailing newline now returns a normal
envelope instead of a traceback.

A trailing space, for what it is worth, was already harmless — Z.AI accepts it.
Only the newline breaks, which is why this is worth fixing rather than
documenting.
