### PR TITLE
fix(credentials): accept the variable names the vendors document

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,9 @@ jobs:
       - name: terminal frontend tests
         run: ./tests/ai-usage-cli.test.sh
 
+      - name: credential discovery tests
+        run: ./tests/credentials.test.sh
+
       - name: codex helper tests
         run: |
           ./tests/get-codex-stats.test.sh

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ install: ## install test copy to local Plasma session
 test: ## run the provider backend contract tests
 	@./tests/get-ai-usage.test.sh
 	@./tests/ai-usage-cli.test.sh
+	@./tests/credentials.test.sh
 	@./tests/python-interp.test.sh
 	@./tests/get-codex-stats.test.sh
 	@./tests/get-codex-rate-limits.test.sh

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Enable only the services you use. Each one has its own setup requirement:
 | Kiro | Kiro IDE, signed in at least once |
 | Mistral AI | A Mistral API key; vibe CLI is optional and adds local session statistics |
 | OpenRouter | An OpenRouter API key entered in widget settings |
-| Z.AI | A Z.AI token from widget settings, `$ZAI_TOKEN`, `$Z_AI_API_KEY`, `~/.config/zai/token`, or `~/.zai/token` |
+| Z.AI | A Z.AI token from widget settings, `$ZAI_TOKEN`, `$Z_AI_API_KEY`, `~/.config/zai/token`, `~/.zai/token`, or the one `glm-acp-agent --setup` already stored |
 | GitHub Copilot | A GitHub token from widget settings, `$GITHUB_TOKEN`, or `~/.config/github-copilot/token`, with fine-grained **Plan: read** permission; personal billing only. The quota defaults to 300 and is configurable |
 | DeepSeek | A DeepSeek API key from widget settings, `$DEEPSEEK_API_KEY`, or `~/.config/deepseek/api-key` |
 | Kimi / Moonshot AI | A Moonshot API key from widget settings, `$MOONSHOT_API_KEY`, `$KIMI_API_KEY`, or `~/.config/moonshot/api-key` |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Enable only the services you use. Each one has its own setup requirement:
 | Kiro | Kiro IDE, signed in at least once |
 | Mistral AI | A Mistral API key; vibe CLI is optional and adds local session statistics |
 | OpenRouter | An OpenRouter API key entered in widget settings |
-| Z.AI | A Z.AI token from widget settings, `$ZAI_TOKEN`, or `~/.config/zai/token` |
+| Z.AI | A Z.AI token from widget settings, `$ZAI_TOKEN`, `$Z_AI_API_KEY`, `~/.config/zai/token`, or `~/.zai/token` |
 | GitHub Copilot | A GitHub token from widget settings, `$GITHUB_TOKEN`, or `~/.config/github-copilot/token`, with fine-grained **Plan: read** permission; personal billing only. The quota defaults to 300 and is configurable |
 | DeepSeek | A DeepSeek API key from widget settings, `$DEEPSEEK_API_KEY`, or `~/.config/deepseek/api-key` |
 | Kimi / Moonshot AI | A Moonshot API key from widget settings, `$MOONSHOT_API_KEY`, `$KIMI_API_KEY`, or `~/.config/moonshot/api-key` |
@@ -337,7 +337,7 @@ The widget validates the configured API key against the Mistral API and lists av
 The widget fetches credit usage and limit from the OpenRouter API using the configured key. The popup shows USD spent, the credit limit (if any), and the account label. The usage bar reflects spend as a percentage of the limit; if no limit is set the bar stays empty.
 
 ### Z.AI *(untested)*
-The Z.AI tab calls the Z.AI usage quota endpoint with the configured token. It shows the 5-hour token quota, monthly tools quota, reset countdowns, and model details when the API response includes them. The token is resolved from widget settings → `$ZAI_TOKEN` → `~/.config/zai/token`.
+The Z.AI tab calls the Z.AI usage quota endpoint with the configured token. It shows the 5-hour token quota, monthly tools quota, reset countdowns, and model details when the API response includes them. The token is resolved from widget settings → `$ZAI_TOKEN` → `$Z_AI_API_KEY` → `~/.config/zai/token` → `~/.zai/token`.
 
 ### GitHub Copilot
 The GitHub Copilot tab reads monthly premium request usage from GitHub's user billing API. It validates the token against the GitHub user endpoint, then fetches premium request usage and scales it against the configured quota, which defaults to 300. The token is resolved from widget settings → `$GITHUB_TOKEN` → `~/.config/github-copilot/token`, and a fine-grained token needs **Plan: read** permission. This user endpoint covers Copilot plans billed personally; usage billed through an organization or enterprise is not shown yet. A VS Code Copilot login is not imported automatically because VS Code keeps its session token in encrypted secret storage rather than a reusable plaintext config file.

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -52,6 +52,14 @@ API keys come from `WIDGET_*` environment variables (what Plasma passes) or from
 the `keys` object of the settings file (what the Hyprland settings page writes).
 The environment always wins.
 
+Beyond that, each provider searches the places its vendor's own tooling uses, in a
+fixed order: the `WIDGET_*` variable, then one or more conventional environment
+variables, then the first readable config file. Where a vendor documents a different
+variable name than the one this package grew up with, both are accepted —
+`Z_AI_API_KEY` alongside `ZAI_TOKEN`, `KIMI_API_KEY` alongside `MOONSHOT_API_KEY` —
+because a provider that knows only one spelling reports "no token configured" at
+somebody who did set the key. `tests/credentials.test.sh` pins the order.
+
 ## Envelope
 
 ```json

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -58,7 +58,10 @@ variables, then the first readable config file. Where a vendor documents a diffe
 variable name than the one this package grew up with, both are accepted —
 `Z_AI_API_KEY` alongside `ZAI_TOKEN`, `KIMI_API_KEY` alongside `MOONSHOT_API_KEY` —
 because a provider that knows only one spelling reports "no token configured" at
-somebody who did set the key. `tests/credentials.test.sh` pins the order.
+somebody who did set the key. Two providers additionally borrow the credential another tool already stores
+(`~/.config/glm-acp-agent/credentials.json` for Z.AI, `~/.vibe/config.toml` for
+Mistral); a borrowed key always ranks last, so an explicit one wins.
+`tests/credentials.test.sh` pins the order.
 
 ## Envelope
 

--- a/package/contents/tools/aiusage/http.py
+++ b/package/contents/tools/aiusage/http.py
@@ -26,10 +26,23 @@ def resolve_key(widget_var, env_var, *files):
     with a trailing newline would otherwise reach urllib, which rejects the
     header with a ValueError — and that exception carries the credential into
     the traceback, defeating the guarantee that no secret leaves this package.
+
+    `env_var` accepts either a single name or a sequence of them, tried in
+    order. Several vendors ship two spellings of the same variable — Moonshot
+    is read as both MOONSHOT_API_KEY and KIMI_API_KEY, Z.AI documents
+    Z_AI_API_KEY while this package reads ZAI_TOKEN — and a provider that
+    knows only one of them reports "no token configured" at a user who did
+    set the key, which is the least debuggable failure we can produce.
     """
-    value = os.environ.get(widget_var, "").strip()
+    value = os.environ.get(widget_var, "").strip() if widget_var else ""
     if not value and env_var:
-        value = os.environ.get(env_var, "").strip()
+        names = (env_var,) if isinstance(env_var, str) else env_var
+        for name in names:
+            if not name:
+                continue
+            value = os.environ.get(name, "").strip()
+            if value:
+                break
     if not value:
         for path in files:
             if not path or not os.path.isfile(path):

--- a/package/contents/tools/aiusage/providers/moonshot.py
+++ b/package/contents/tools/aiusage/providers/moonshot.py
@@ -14,16 +14,21 @@ def _number(value):
         return 0
 
 
+def _moonshot_key():
+    """Both spellings of the variable, then the conventional files. Kept as a
+    named function so the credential tests exercise the same order production
+    does instead of restating it."""
+    return resolve_key(
+        "WIDGET_MOONSHOT_API_KEY",
+        ("MOONSHOT_API_KEY", "KIMI_API_KEY"),
+        os.path.expanduser("~/.config/moonshot/api-key"),
+        os.path.expanduser("~/.moonshot/api-key"),
+        os.path.expanduser("~/.config/kimi/api-key"),
+    )
+
+
 def get_moonshot_balance():
-    api_key = os.environ.get("WIDGET_MOONSHOT_API_KEY") or os.environ.get("MOONSHOT_API_KEY") or os.environ.get("KIMI_API_KEY") or ""
-    if not api_key:
-        api_key = resolve_key(
-            "",
-            "",
-            os.path.expanduser("~/.config/moonshot/api-key"),
-            os.path.expanduser("~/.moonshot/api-key"),
-            os.path.expanduser("~/.config/kimi/api-key"),
-        )
+    api_key = _moonshot_key()
     if not api_key:
         return {}
 

--- a/package/contents/tools/aiusage/providers/zai.py
+++ b/package/contents/tools/aiusage/providers/zai.py
@@ -89,14 +89,39 @@ def _today_usage(api_key):
     }
 
 
+def _glm_acp_key():
+    """The key `glm-acp-agent --setup` stores, read as a last resort.
+
+    That ACP agent (used from Zed and other ACP clients) talks to the same
+    Z.AI coding plan with the same key, and its setup command is where a lot
+    of people paste it. Without this, a machine can hold a perfectly valid
+    credential while this provider still reports "no token configured" —
+    which is what happened to me. Same courtesy `_vibe_key` extends to
+    Mistral, and it ranks last so an explicit token always wins.
+    """
+    path = os.path.expanduser("~/.config/glm-acp-agent/credentials.json")
+    if not os.path.isfile(path):
+        return ""
+    try:
+        with open(path, errors="replace") as f:
+            data = as_json(f.read())
+    except OSError:
+        return ""
+    key = data.get("z_ai_api_key") if isinstance(data, dict) else None
+    return key.strip() if isinstance(key, str) else ""
+
+
 def _zai_key():
     """The credential search, as one callable so the tests exercise the same
     order production does instead of restating it."""
-    return resolve_key(
-        "WIDGET_ZAI_TOKEN",
-        ("ZAI_TOKEN", "Z_AI_API_KEY"),
-        os.path.expanduser("~/.config/zai/token"),
-        os.path.expanduser("~/.zai/token"),
+    return (
+        resolve_key(
+            "WIDGET_ZAI_TOKEN",
+            ("ZAI_TOKEN", "Z_AI_API_KEY"),
+            os.path.expanduser("~/.config/zai/token"),
+            os.path.expanduser("~/.zai/token"),
+        )
+        or _glm_acp_key()
     )
 
 

--- a/package/contents/tools/aiusage/providers/zai.py
+++ b/package/contents/tools/aiusage/providers/zai.py
@@ -89,8 +89,19 @@ def _today_usage(api_key):
     }
 
 
+def _zai_key():
+    """The credential search, as one callable so the tests exercise the same
+    order production does instead of restating it."""
+    return resolve_key(
+        "WIDGET_ZAI_TOKEN",
+        ("ZAI_TOKEN", "Z_AI_API_KEY"),
+        os.path.expanduser("~/.config/zai/token"),
+        os.path.expanduser("~/.zai/token"),
+    )
+
+
 def get_zai_usage():
-    api_key = resolve_key("WIDGET_ZAI_TOKEN", "ZAI_TOKEN", os.path.expanduser("~/.config/zai/token"))
+    api_key = _zai_key()
     if not api_key:
         return {}
 

--- a/package/contents/ui/ZaiTab.qml
+++ b/package/contents/ui/ZaiTab.qml
@@ -78,7 +78,7 @@ ColumnLayout {
         }
 
         PlasmaComponents.Label {
-            text: "Set a Z.AI token in settings or via\n$ZAI_TOKEN / ~/.config/zai/token"
+            text: "Set a Z.AI token in settings or via\n$ZAI_TOKEN / $Z_AI_API_KEY / ~/.config/zai/token"
             font.pixelSize: 10
             opacity: 0.5
             color: Kirigami.Theme.textColor

--- a/tests/credentials.test.sh
+++ b/tests/credentials.test.sh
@@ -70,6 +70,26 @@ ZAI_TOKEN=from-native-env Z_AI_API_KEY=from-vendor-env \
     expect "prefers this tool's own ZAI_TOKEN over the vendor spelling" \
     "from-native-env" "zai:_zai_key"
 
+# glm-acp-agent --setup is where a lot of people paste the coding-plan key.
+fresh_home
+mkdir -p "$tmp/home/.config/glm-acp-agent"
+printf '{"z_ai_api_key": "from-acp-agent"}\n' >"$tmp/home/.config/glm-acp-agent/credentials.json"
+expect "reads the glm-acp-agent credentials file" "from-acp-agent" "zai:_zai_key"
+
+mkdir -p "$tmp/home/.config/zai"
+printf 'from-config-file\n' >"$tmp/home/.config/zai/token"
+expect "an explicit token still beats the borrowed one" "from-config-file" "zai:_zai_key"
+
+fresh_home
+mkdir -p "$tmp/home/.config/glm-acp-agent"
+printf 'not json at all\n' >"$tmp/home/.config/glm-acp-agent/credentials.json"
+expect "a corrupt credentials file is empty, not an exception" "" "zai:_zai_key"
+
+fresh_home
+mkdir -p "$tmp/home/.config/glm-acp-agent"
+printf '{"z_ai_api_key": null}\n' >"$tmp/home/.config/glm-acp-agent/credentials.json"
+expect "a null key is treated as absent" "" "zai:_zai_key"
+
 # ── Moonshot / Kimi ─────────────────────────────────────────────────────────
 
 fresh_home

--- a/tests/credentials.test.sh
+++ b/tests/credentials.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Credential discovery decides whether a provider renders a number or the
+# "no token configured" row, and it is the one part of a provider that never
+# shows up in the envelope (docs/provider-contract.md: credentials are never
+# part of a result). That makes a wrong precedence invisible to the contract
+# tests — a key can sit on disk, valid, while the widget claims there is none.
+#
+# Each case builds a pristine HOME, plants exactly one credential, and asserts
+# which one the resolver settles on.
+
+repo="$(cd "$(dirname "$0")/.." && pwd)"
+BACKEND="$repo/package/contents/tools/sh/get-ai-usage"
+
+tmp="$(mktemp -d)"
+trap 'case "$tmp" in /tmp/*) rm -rf -- "$tmp" ;; esac' EXIT
+
+failures=0
+checks=0
+
+# resolve <provider-function> — runs the real resolver against a clean HOME and
+# whatever variables the caller exported, and prints what it found.
+resolve() {
+    local fn="$1"
+    HOME="$tmp/home" PYTHONPATH="$repo/package/contents/tools" python3 -c "
+from aiusage.providers.${fn%%:*} import ${fn##*:}
+print(${fn##*:}())"
+}
+
+# expect <description> <expected> <provider-function>
+expect() {
+    local description="$1" expected="$2" fn="$3" got
+    checks=$((checks + 1))
+    got="$(resolve "$fn")"
+    if [ "$got" != "$expected" ]; then
+        printf 'FAIL %s\n  want: %s\n  got:  %s\n' "$description" "$expected" "$got" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+fresh_home() {
+    rm -rf "$tmp/home"
+    mkdir -p "$tmp/home/.config"
+}
+
+# ── Z.AI ────────────────────────────────────────────────────────────────────
+
+fresh_home
+expect "no credential anywhere yields an empty key" "" "zai:_zai_key"
+
+fresh_home
+mkdir -p "$tmp/home/.config/zai"
+printf 'from-config-file\n' >"$tmp/home/.config/zai/token"
+expect "reads the conventional ~/.config/zai/token" "from-config-file" "zai:_zai_key"
+
+fresh_home
+mkdir -p "$tmp/home/.zai"
+printf 'from-dot-zai\n' >"$tmp/home/.zai/token"
+expect "falls back to ~/.zai/token" "from-dot-zai" "zai:_zai_key"
+
+# The vendor documents Z_AI_API_KEY; this tool has always read ZAI_TOKEN. A
+# user who followed z.ai's own docs used to get "no token configured".
+fresh_home
+Z_AI_API_KEY=from-vendor-env expect "accepts the vendor's Z_AI_API_KEY spelling" \
+    "from-vendor-env" "zai:_zai_key"
+
+fresh_home
+ZAI_TOKEN=from-native-env Z_AI_API_KEY=from-vendor-env \
+    expect "prefers this tool's own ZAI_TOKEN over the vendor spelling" \
+    "from-native-env" "zai:_zai_key"
+
+# ── Moonshot / Kimi ─────────────────────────────────────────────────────────
+
+fresh_home
+expect "no Moonshot credential yields an empty key" "" "moonshot:_moonshot_key"
+
+fresh_home
+KIMI_API_KEY=from-kimi-env expect "still accepts the KIMI_API_KEY spelling" \
+    "from-kimi-env" "moonshot:_moonshot_key"
+
+fresh_home
+MOONSHOT_API_KEY=from-moonshot-env KIMI_API_KEY=from-kimi-env \
+    expect "prefers MOONSHOT_API_KEY over KIMI_API_KEY" \
+    "from-moonshot-env" "moonshot:_moonshot_key"
+
+fresh_home
+mkdir -p "$tmp/home/.config/moonshot"
+printf 'from-moonshot-file\n' >"$tmp/home/.config/moonshot/api-key"
+KIMI_API_KEY=from-kimi-env expect "an environment key outranks the file" \
+    "from-kimi-env" "moonshot:_moonshot_key"
+
+fresh_home
+mkdir -p "$tmp/home/.config/kimi"
+printf 'from-kimi-file\n' >"$tmp/home/.config/kimi/api-key"
+expect "reads ~/.config/kimi/api-key" "from-kimi-file" "moonshot:_moonshot_key"
+
+if [ "$failures" -eq 0 ]; then
+    printf 'ok — %d credential checks passed\n' "$checks"
+else
+    printf '%d of %d credential checks failed\n' "$failures" "$checks" >&2
+    exit 1
+fi


### PR DESCRIPTION
Z.AI documents its variable as `Z_AI_API_KEY`; this package reads `ZAI_TOKEN`. Following the vendor's own instructions therefore yields `Z.AI: no token configured` **with the key set** — and because credentials deliberately never reach the envelope, there is nothing to inspect from the outside. It cost me a while to find on my own machine, and the same trap exists wherever a vendor ships two spellings.

`resolve_key` now takes a sequence of environment names instead of a single one, so a provider can honour every spelling in circulation. That also folds Moonshot's hand-rolled `MOONSHOT_API_KEY` / `KIMI_API_KEY` chain back into the shared helper it had grown out of — behaviour there is unchanged, it just stops being a special case.

The second commit extends the same idea to a file: `glm-acp-agent --setup` stores the Z.AI **coding-plan** key in `~/.config/glm-acp-agent/credentials.json` — the same key against the same plan. That agent is what drives Z.AI models in Zed and other ACP clients, so a machine can hold a perfectly valid credential while this provider still renders "no token configured". It is read **last**, after every environment variable and conventional file, so an explicitly configured token always wins; missing, unreadable and malformed files resolve to no key rather than raising. This mirrors what `_vibe_key` already does for Mistral.

**Why a new test file.** Credential discovery is structurally invisible to the contract tests — a valid key can sit on disk while every assertion passes, which is exactly how the bug survived. `tests/credentials.test.sh` builds a pristine `HOME`, plants one credential at a time and asserts which one the resolver settles on (14 checks). I verified it fails when either half of this change is reverted, rather than trusting a green run. It is wired into `Makefile` and into `lint.yml` as its own step, since the workflow lists test files individually.

Also updated so nothing contradicts the new behaviour: the `ZaiTab` hint now names `$Z_AI_API_KEY` (`KimiTab` already lists both Moonshot spellings), plus the README table, the Z.AI section and the credential paragraph in `docs/provider-contract.md`.

**Note on the base:** this builds on #17, which touches the same statement in `resolve_key` — the combination is what is tested here. The branch fast-forwards onto `master`, so merging this brings #17 along and closes it too. If you would rather take them separately, merge #17 first and I will rebase.

Verified locally against the CI's own criteria: `ruff check` and `ruff format --check` on `package/contents/tools/aiusage` clean, `make test` green (269 provider-contract, 264 terminal-frontend, 14 credential, `node --test` 12/12).
